### PR TITLE
Update how-to-resume-suspended-orchestration-instances.md

### DIFF
--- a/biztalk/core/how-to-resume-suspended-orchestration-instances.md
+++ b/biztalk/core/how-to-resume-suspended-orchestration-instances.md
@@ -46,7 +46,7 @@ If you have suspended orchestration instances that are listed as "suspended resu
   
 6.  Click **Run Query**.  
   
-7.  In the query results list, right-click the orchestration instance you want to terminate, and then click **Resume Instance** or **Resume Instances**. This allows you to select which instances to resume.  
+7.  In the query results list, right-click the orchestration instance you want to resume, and then click **Resume Instance** or **Resume Instances**. This allows you to select which instances to resume.  
   
      [Service Instance States](../core/service-instance-states.md) provides more information on the on the suspended state.  
   


### PR DESCRIPTION
Fixing copy/paste error where it says right-click the orchestration instance to <terminate> instead of <resume>