### PR TITLE
C5439: Broken hyperlink due to duplicated reference

### DIFF
--- a/biztalk/core/known-issues-with-schema-generation-and-validation.md
+++ b/biztalk/core/known-issues-with-schema-generation-and-validation.md
@@ -31,7 +31,7 @@ This topic provides information about known issues with schema generation and va
  Your schema can contain an infinite loop when it contains a circular reference to a node with a **Min Occurs** property value greater than or equal to one, essentially preventing a termination condition. Instance message generation will artificially terminate so that the generation operation can complete, but the produced instance message will thereby not conform to the schema from which it was generated. Such schemas are usually suspect.  
   
 ## Validation of XML instance fails for document schema which has the target namespace="http://www.w3.org/XML/1998/namespace"  
- The “ HYPERLINK "http://www.w3.org/XML/1998/namespace" http://www.w3.org/XML/1998/namespace” is a reserved namespace whose prefix should be “XML”. You can manually edit the prefix to “XML”.
+ The HYPERLINK "http://www.w3.org/XML/1998/namespace" is a reserved namespace whose prefix should be “XML”. You can manually edit the prefix to “XML”.
 
 ## See also
 More details on these properties [!INCLUDE[ui-guidance-developers-reference](../includes/ui-guidance-developers-reference.md)].


### PR DESCRIPTION
Hello, @MandiOhlinger,
Verified that reported content is duplicated and needs to be removed in order to avoid missing hyperlink in localized versions. Could you help to review this and merge this PR?
Many thanks in advance.