### PR TITLE
Update how-to-configure-the-backup-biztalk-server-job.md

### DIFF
--- a/biztalk/core/how-to-configure-the-backup-biztalk-server-job.md
+++ b/biztalk/core/how-to-configure-the-backup-biztalk-server-job.md
@@ -115,7 +115,7 @@ To configure this job, you'll need to:
      The MarkAndBackupLog step marks the logs for backup, and then backs them up.  
   
     > [!IMPORTANT]
-    >  To avoid potential data loss, the *\<destination path>* should be a computer to store the database logs that is different from the computer with the original database logs.  
+    >  To avoid **potential data loss** and for **performance improvement**, the *\<destination path>* should be set to a different computer, or hard drive, different from what is used to store the original database logs.  
   
      Select **OK**.  
   


### PR DESCRIPTION
Change the important note that says the *\<destination path>* should be set to a different computer ... I add it or hard drive. And also add another reason why you should that, not only for avoid potential data loss but also performance improvement