### PR TITLE
C13960: Extra hyperlink due to potential incorrect structure

### DIFF
--- a/biztalk/core/distinguished-fields-in-disassembler-pipeline-components.md
+++ b/biztalk/core/distinguished-fields-in-disassembler-pipeline-components.md
@@ -63,7 +63,7 @@ Distinguished fields defined in a schema are written to the message context by t
   
  the XML Disassembler writes a distinguished field on a message context as follows:  
   
- Name of the property on the context: "/*[local-name()='PO' and namespace-uri()='http://SendHtmlMessage.PO']/\*[local-name()='Price' and namespace-uri()='']"  
+ Name of the property on the context: `"/*[local-name()='PO' and namespace-uri()='http://SendHtmlMessage.PO']/\*[local-name()='Price' and namespace-uri()='']"`  
   
  Namespace of the property: http://schemas.microsoft.com/BizTalk/2003/btsDistinguishedFields  
   


### PR DESCRIPTION
Hello, @MandiOhlinger,

Localization team has reported source content issue that causes localized version to have different format compared to en-us version. It seems that the text should be treated as code box to avoid different formats.

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please, let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR.

Many thanks in advance.