### PR TITLE
C13970: Extra hyperlink due to potential incorrect structure

### DIFF
--- a/biztalk/core/walkthrough-testing-the-policy.md
+++ b/biztalk/core/walkthrough-testing-the-policy.md
@@ -181,7 +181,8 @@ This walkthrough provides step-by-step procedures for testing the policy you cre
 |Field name|XPath Selector|XPath Field|XPath Selector (simplified form)|XPath Field<br /><br /> (simplified form)|  
 |----------------|--------------------|-----------------|----------------------------------------|-----------------------------------------|  
 |Quantity|/*[local-name()='PurchaseOrder' and namespace-uri()='http://EAISolution.PurchaseOrder']/\*[local-name()='Item' and namespace-uri()='']|*[local-name()='Quantity' and namespace-uri()='']|/PurchaseOrder/Item|Quantity|  
-|Status|/*[local-name()='PurchaseOrder' and namespace-uri()='http://EAISolution.PurchaseOrder']|*[local-name()='Status' and namespace-uri()='']|/PurchaseOrder|Status|  
+|Status|/*[local-name()='PurchaseOrder' and namespace-uri()='http://EAISolution.PurchaseOrder']|*[local-name()='Status' and namespace-uri()='']|/PurchaseOrder|Status|
+<!---Loc Comment: Please, verify strucutre in line 183 and 184--->
   
 #### To view the Xpath Selector and Xpath Field bindings for the Quantity and Status fields  
   


### PR DESCRIPTION
Hello, @MandiOhlinger,

Localization team has reported source content issue that causes localized version to have different format compared to en-us version. It seems that the text become hyperlink on target version.

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please, let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR.

Many thanks in advance.