### PR TITLE
Revert "C13970: Extra hyperlink due to potential incorrect structure"

### DIFF
--- a/biztalk/core/walkthrough-testing-the-policy.md
+++ b/biztalk/core/walkthrough-testing-the-policy.md
@@ -181,8 +181,7 @@ This walkthrough provides step-by-step procedures for testing the policy you cre
 |Field name|XPath Selector|XPath Field|XPath Selector (simplified form)|XPath Field<br /><br /> (simplified form)|  
 |----------------|--------------------|-----------------|----------------------------------------|-----------------------------------------|  
 |Quantity|/*[local-name()='PurchaseOrder' and namespace-uri()='http://EAISolution.PurchaseOrder']/\*[local-name()='Item' and namespace-uri()='']|*[local-name()='Quantity' and namespace-uri()='']|/PurchaseOrder/Item|Quantity|  
-|Status|/*[local-name()='PurchaseOrder' and namespace-uri()='http://EAISolution.PurchaseOrder']|*[local-name()='Status' and namespace-uri()='']|/PurchaseOrder|Status|
-<!---Loc Comment: Please, verify strucutre in line 183 and 184--->
+|Status|/*[local-name()='PurchaseOrder' and namespace-uri()='http://EAISolution.PurchaseOrder']|*[local-name()='Status' and namespace-uri()='']|/PurchaseOrder|Status|  
   
 #### To view the Xpath Selector and Xpath Field bindings for the Quantity and Status fields  
   


### PR DESCRIPTION
Reverts MicrosoftDocs/biztalk-docs#201

Hello, @MandiOhlinger, 

This PR was opened to look for a fix. There is an extra hyperlink on target versions due to potential incorrect structure. Could you, please, verify the strucuturesin lines 183 and 184? Please, refer yo the image attached for further details. Many thanks in advance for your time. 

![13970](https://user-images.githubusercontent.com/15142970/38819676-69ef9b40-4172-11e8-8766-b87a5fcfe595.PNG)
