### PR TITLE
L16380: Shows span tags on target version due to "@"

### DIFF
--- a/biztalk/adapters-and-accelerators/adapter-sap/syntax-for-a-select-statement-in-sap.md
+++ b/biztalk/adapters-and-accelerators/adapter-sap/syntax-for-a-select-statement-in-sap.md
@@ -204,9 +204,9 @@ Table | '['Table']'
   
 -   A SELECT statement using [!INCLUDE[adoprovidersapshort](../../includes/adoprovidersapshort-md.md)] supports parameter names for argument values in a SELECT query. However, make sure you follow these rules with respect to parameter names:  
   
-    -   In the SELECT query, an "@" symbol must precede the parameter name.  
+    -   In the SELECT query, an "\@" symbol must precede the parameter name.  
   
-    -   The "@" symbol must be followed by an alphabetic character (A-Z or a-z).  
+    -   The "\@" symbol must be followed by an alphabetic character (A-Z or a-z).  
   
     -   The parameter name can contain alphanumeric characters (A-Z, a-z, or 0-9) and special characters. The only special characters that can be included in the parameter name are underscore "_" and hash "#".  
   


### PR DESCRIPTION
Hello, @MandiOhlinger, 

Localization team has reported source content issue that causes localized version to have broken format compared to en-us version. We need to escape @ to avoid loc issues,

Please, help to check my proper if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR, or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR. 

Many thanks in advance.