### PR TITLE
L20437: Character in file name casusing localiztion problems

### DIFF
--- a/his/core/application-integration-programmer’s-guide2.md
+++ b/his/core/application-integration-programmer’s-guide2.md
@@ -13,6 +13,8 @@ author: "gplarsen"
 ms.author: "hisdocs; plarsen"
 manager: "anneta"
 ---
+
+<!--- Loc Comment: File name should read as application-integration-programmers-guide2---->
 # Application Integration Programmer’s Guide
 This section of the Microsoft Host Integration Server Software Development Kit (SDK) provides information required to develop software to integrate .NET applications with Customer Information Control System (CICS) and Information Management System (IMS) transactions on IBM mainframe z/OS computers and callable RPG programs on midrange i5/OS computers.  
   


### PR DESCRIPTION
Hello, @gplarsen,

Localization team has reported source content issue that causes localized version to have broken format compared to en-us version.  The character ' in the file name is breaking target format.
  
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.