### PR TITLE
Bulk fix to change example URLs that are breaking localization, into code blocks

### DIFF
--- a/biztalk/core/publish-orchestration-as-web-service--biztalk-web-services-publishing-wizard.md
+++ b/biztalk/core/publish-orchestration-as-web-service--biztalk-web-services-publishing-wizard.md
@@ -93,7 +93,7 @@ You use the BizTalk Web Services Publishing Wizard to publish an orchestration a
     > [!NOTE]
     >  The same combination of target namespace/root element name can only be added once as a request SOAP header and once as a response SOAP header.  
   
-9. On the **Web Service Project** page, in the **Project name** text box, type the name for the project. You can accept the default location (http://localhost/<*project_name*>), type a location for the project in the **Project location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
+9. On the **Web Service Project** page, in the **Project name** text box, type the name for the project. You can accept the default location (`http://localhost/<project_name>`), type a location for the project in the **Project location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
   
     -   **Overwrite existing project.** This option is only available if the project location already exists. You will only be able to publish to the same location if you select this option. Otherwise, you must enter a different project location.  
   
@@ -102,10 +102,10 @@ You use the BizTalk Web Services Publishing Wizard to publish an orchestration a
     -   **Create BizTalk receive locations.** This option automatically creates the SOAP adapter receive ports and locations that correspond to each generated .asmx file. If a receive location already exists, it is not replaced. Receive locations for the SOAP adapter are resolved using the format /\<*virtual directory name*\>/\<*orchestration namespace_typename_portname*\>.asmx. After selecting this option, choose the application where the receive ports and locations will be generated.  
   
         > [!NOTE]
-        >  The project location can exist on a different server. To publish a Web service to a different server, type the project name as **http://<*servername*>/<*project_name*>**.  
+        >  The project location can exist on a different server. To publish a Web service to a different server, type the project name as `http://<servername>/<project_name>`.  
   
         > [!NOTE]
-        >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, http://localhost:8080/<*project_name*>.  
+        >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, `http://localhost:8080/<project_name>`.  
   
         > [!NOTE]
         >  When using the wizard to create receive locations, the wizard creates the receive locations using the default values. The default value for the receive pipeline is the **Microsoft.BizTalk.DefaultPipelines.PassThruReceive** pipeline. If messages received through the published Web service require any special pipeline processing (for example, validation, correlation / property promotion, or inbound/outbound maps) then you should set the receive pipeline to **Microsoft.BizTalk.DefaultPipelines.XMLReceive**, or to a custom pipeline.  

--- a/biztalk/core/publish-orchestrations-as-wcf-services--biztalk-wcf-service-publishing-wizard.md
+++ b/biztalk/core/publish-orchestrations-as-wcf-services--biztalk-wcf-service-publishing-wizard.md
@@ -83,7 +83,7 @@ You use the BizTalk WCF Service Publishing Wizard to publish orchestrations as W
   
      ![WCF Service Properties page](../core/media/07518c78-bcae-4274-bb14-aeef107ee4c6.gif "07518c78-bcae-4274-bb14-aeef107ee4c6")  
   
-11. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (http://localhost/<*BizTalk Assembly Name*>), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
+11. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (`http://localhost/<BizTalk Assembly Name>`), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
   
     - **Overwrite existing project.** This option is only available if the Web directory already exists. You will be able to publish to the same location only if you select this option. Otherwise, you must enter a different project location.  
   
@@ -94,10 +94,10 @@ You use the BizTalk WCF Service Publishing Wizard to publish orchestrations as W
       ![WCF Service location page](../core/media/76285470-1520-4d77-a5b6-c58cbe8fc575.gif "76285470-1520-4d77-a5b6-c58cbe8fc575")  
   
     > [!NOTE]
-    >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as http://<*servername*>/<*WCF service location*>.  
+    >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as `http://<servername>/<WCF service location>`.  
   
     > [!NOTE]
-    >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, http://<*servername*>:8080/<*WCF service location*>.  
+    >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, `http://<servername>:8080/<WCF service location>`.  
   
     > [!NOTE]
     >  When using the wizard to create receive locations, the wizard creates the receive locations using the default values. The default value for the receive pipeline is the **Microsoft.BizTalk.DefaultPipelines.PassThruReceive** pipeline. If messages received through the published WCF services require any special pipeline processing (for example, validation, correlation/property promotion, or inbound/outbound maps) then you should set the receive pipeline to **Microsoft.BizTalk.DefaultPipelines.XMLReceive**, or to a custom pipeline, using the BizTalk Server Administration console.  

--- a/biztalk/core/publish-receive-location-service-metadata-biztalk-wcf-service-publishing-wizard.md
+++ b/biztalk/core/publish-receive-location-service-metadata-biztalk-wcf-service-publishing-wizard.md
@@ -68,7 +68,7 @@ You use the BizTalk WCF Service Publishing Wizard to create a WCF service to pub
 
     ![WCF Service Properties page](../core/media/07518c78-bcae-4274-bb14-aeef107ee4c6.gif "07518c78-bcae-4274-bb14-aeef107ee4c6")  
 
-9. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (http://localhost/<*BizTalk Assembly Name*>), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
+9. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (`http://localhost/<BizTalk Assembly Name>`), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
 
    - **Overwrite existing project.** This option is available only if the Web directory already exists. You will be able to publish to the same location only if you select this option. Otherwise, you must enter a different project location.  
 
@@ -79,10 +79,10 @@ You use the BizTalk WCF Service Publishing Wizard to create a WCF service to pub
      ![WCF Service location page](../core/media/76285470-1520-4d77-a5b6-c58cbe8fc575.gif "76285470-1520-4d77-a5b6-c58cbe8fc575")  
 
      > [!NOTE]
-     >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as http://<*servername*>/<*WCF service location*>.  
+     >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as `http://<servername>/<WCF service location>`.  
 
      > [!NOTE]
-     >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, http://<*servername*>:8080/<*WCF service location*>.  
+     >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, `http://<servername>:8080/<WCF service location>`.  
 
      > [!NOTE]
      >  The BindingInfo.xml file that the wizard creates in the App_DataTemp folder of the Web application uses the default values for the pipelines. The default value for the receive pipeline is the **Microsoft.BizTalk.DefaultPipelines.XMLReceive** pipeline, and the default value for the send pipeline is the **Microsoft.BizTalk.DefaultPipelines.PassThruTransmit** pipeline.  

--- a/biztalk/core/publish-schemas-as-wcf-services--use-the-biztalk-wcf-service-publishing-wizard.md
+++ b/biztalk/core/publish-schemas-as-wcf-services--use-the-biztalk-wcf-service-publishing-wizard.md
@@ -90,7 +90,7 @@ You use the BizTalk WCF Service Publishing Wizard to publish schemas as WCF serv
   
      ![WCF Service Properties page](../core/media/07518c78-bcae-4274-bb14-aeef107ee4c6.gif "07518c78-bcae-4274-bb14-aeef107ee4c6")  
   
-11. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (http://localhost/<*Web service description name*>), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
+11. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (`http://localhost/<Web service description name>`), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
   
     - **Overwrite existing project.** This option is available only if the Web directory already exists. You will be able to publish to the same location only if you select this option. Otherwise, you must enter a different project location.  
   
@@ -101,10 +101,10 @@ You use the BizTalk WCF Service Publishing Wizard to publish schemas as WCF serv
       ![WCF Service location page](../core/media/76285470-1520-4d77-a5b6-c58cbe8fc575.gif "76285470-1520-4d77-a5b6-c58cbe8fc575")  
   
     > [!NOTE]
-    >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as http://<*servername*>/<*WCF service location*>.  
+    >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as `http://<servername>/<WCF service location>`.  
   
     > [!NOTE]
-    >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, http://<*servername*>:8080/<*WCF service location*>.  
+    >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, `http://<servername>:8080/<WCF service location>`.  
   
     > [!NOTE]
     >  When using the wizard to create receive locations, the wizard creates the receive locations using the default values. The default value for the receive pipeline is the **Microsoft.BizTalk.DefaultPipelines.PassThruReceive** pipeline. If messages received through the published WCF services require any special pipeline processing (for example, validation, correlation/property promotion, or inbound/outbound maps) then you should set the receive pipeline to **Microsoft.BizTalk.DefaultPipelines.XMLReceive**, or to a custom pipeline by using the BizTalk Administration console.  

--- a/biztalk/core/publish-service-metadata-for-a-wcf-receive-location-for-content-based-routing.md
+++ b/biztalk/core/publish-service-metadata-for-a-wcf-receive-location-for-content-based-routing.md
@@ -72,7 +72,7 @@ You use the BizTalk WCF Service Publishing Wizard to create a WCF service to pub
 
     ![WCF Service Properties page](../core/media/07518c78-bcae-4274-bb14-aeef107ee4c6.gif "07518c78-bcae-4274-bb14-aeef107ee4c6")  
 
-9. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (http://localhost/<*Web service description name*>), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
+9. On the **WCF Service Location** page, in the **Location** text box, type the Web directory name where the WCF services are generated. You can accept the default location (`http://localhost/<Web service description name>`), type a location for the WCF services in the **Location** text box, or click **Browse** and select a Web directory. Select any of the following options:  
 
    - **Overwrite existing project.** This option is available only if the Web directory already exists. You will be able to publish to the same location only if you select this option. Otherwise, you must enter a different project location.  
 
@@ -83,10 +83,10 @@ You use the BizTalk WCF Service Publishing Wizard to create a WCF service to pub
      ![WCF Service location page](../core/media/76285470-1520-4d77-a5b6-c58cbe8fc575.gif "76285470-1520-4d77-a5b6-c58cbe8fc575")  
 
      > [!NOTE]
-     >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as http://<*servername*>/<*WCF service location*>.  
+     >  The project location can exist on a different server. To publish the WCF services to a different server, type the project name as `http://<servername>/<WCF service location>`.  
 
      > [!NOTE]
-     >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, http://<*servername*>:8080/<*WCF service location*>.  
+     >  The project location can exist on a non-default Web site. When publishing to a non-default Web site, include the port number of the Web site in the URL. For example, `http://<servername>:8080/<WCF service location>`.  
 
      > [!NOTE]
      >  The BindingInfo.xml file that the wizard creates in the \App_Data\Temp folder of the Web application uses the default values for the pipelines. The default value for the receive pipeline is the **Microsoft.BizTalk.DefaultPipelines.XMLReceive** pipeline, and the default value for the send pipeline is the **Microsoft.BizTalk.DefaultPipelines.PassThruTransmit** pipeline.  


### PR DESCRIPTION
This is a bulk fix the change example URL text into inline code blocks, to fix an issue LOC is seeing where the parsing of the URLs is breaking their MT tool.