### PR TITLE
C36309: Escaping example URLs

### DIFF
--- a/biztalk/core/exchange-patterns-for-send-adapters.md
+++ b/biztalk/core/exchange-patterns-for-send-adapters.md
@@ -223,8 +223,8 @@ return responseMsg;
 
 | Adapter alias | Adapter |   OutboundTransportLocation example    |
 |---------------|---------|----------------------------------------|
-|    HTTP://    |  HTTP   |     http://www. MyCompany.com/bar      |
-|   HTTPS://    |  HTTP   |     https://www. MyCompany.com/bar     |
-|    mailto:    |  SMTP   |      mailto:A.User@MyCompany.com       |
+|    HTTP://    |  HTTP   |     `http://www. MyCompany.com/bar`      |
+|   HTTPS://    |  HTTP   |     `https://www. MyCompany.com/bar`     |
+|    mailto:    |  SMTP   |      `mailto:A.User@MyCompany.com`       |
 |    FILE://    |  FILE   | FILE://C:\ MyCompany \\%MessageID%.xml |
 


### PR DESCRIPTION
Hello, @MandiOhlinger ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Example URLs should be escaped in order to avoid creating a link. 

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.