### PR TITLE
C36310: Removing extra spaces to prevent paragraph joining

### DIFF
--- a/biztalk/adapters-and-accelerators/adapter-oracle-ebs/security-with-the-oracle-e-business-suite-adapter-and-biztalk-server.md
+++ b/biztalk/adapters-and-accelerators/adapter-oracle-ebs/security-with-the-oracle-e-business-suite-adapter-and-biztalk-server.md
@@ -33,7 +33,7 @@ When you configure a send port or a receive port (location) by using the BizTalk
   
 ## How Do I Protect Credentials When I Configure a Send Port or a Receive Location?  
  BizTalk solutions use the Microsoft BizTalk WCF-Custom or WCF-Oracle EBS adapter to consume WCF services. The [!INCLUDE[adapteroraclebusinessshort](../../includes/adapteroraclebusinessshort-md.md)] is a WCF binding that enables clients to consume the Oracle E-Business Suite as if it were a WCF service. BizTalk solutions consume the [!INCLUDE[adapteroraclebusinessshort](../../includes/adapteroraclebusinessshort-md.md)] through send ports and receive locations that are configured to use the WCF-Custom or WCF-OracleEBS adapter, which is, in turn, configured to use the [!INCLUDE[adapteroraclebusinessshort](../../includes/adapteroraclebusinessshort-md.md)] as its transport. For more information about how to configure send ports and receive ports (receive locations), including how to configure the WCF-Custom adapter, see [Configure a physical port binding using a port binding file to Oracle Database](../../adapters-and-accelerators/adapter-oracle-ebs/configure-a-physical-port-binding-using-a-port-binding-file-to-oracle-ebs.md).  
-  
+
  You configure the Oracle E-Business Suite credentials from the **Credentials** tab of the **WCF-Custom Transport Properties** dialog box for send ports or from the **Other** tab of the **WCF-Custom Transport Properties** dialog box for receive locations. Because the WCF-Custom or WCF-Oracle EBS adapter supports Enterprise Single Sign-On (SSO), you can choose to provide either a user name and password or an SSO affiliate application on either of these tabs. The following topics discuss both options.  
   
 ### User Name Password Credentials  


### PR DESCRIPTION
Hello, @MandiOhlinger,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Reason: There are two extra spaces in line 36 that are joining two paragraphs.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.