### PR TITLE
C36314: Escaping asterisk that must be shown as plain text

### DIFF
--- a/biztalk/core/managing-biztalk-server-developer-artifacts-with-a-source-control-systems.md
+++ b/biztalk/core/managing-biztalk-server-developer-artifacts-with-a-source-control-systems.md
@@ -100,7 +100,7 @@ Protecting your BizTalk project from unexpected system failures should be a top 
   
 5. Add the following to the end of the list of binary files. Verify there are semicolons between each file type:  
   
-    *.btm;\*.btp;\*.xsd;\*.odx  
+    \*.btm;\*.btp;\*.xsd;\*.odx  
   
 6. Click **OK**.  
   


### PR DESCRIPTION
Hello, @MandiOhlinger,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Reason: Plain asterisks must be escaped.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.