### PR TITLE
Made consistent use of the property name

### DIFF
--- a/biztalk/core/mapping-phase-recoverable-interchange-processing.md
+++ b/biztalk/core/mapping-phase-recoverable-interchange-processing.md
@@ -15,9 +15,9 @@ ms.author: "mandia"
 manager: "anneta"
 ---
 # Mapping Phase (Recoverable Interchange Processing)
-By default, when a message in an interchange fails at the mapping phase of a receive port, the entire interchange is suspended. You can change this behavior by adding a property named **BTS.SuspendMessageOnMapFailure** to the message context, and by setting the value of the context property to `True` from a pipeline component. When this property is set to `True`, the end point manager places the message that failed during mapping in the suspended queue and continues to process remaining messages in the interchange.  
+By default, when a message in an interchange fails at the mapping phase of a receive port, the entire interchange is suspended. You can change this behavior by adding a property named **BTS.SuspendMessageOnMappingFailure** to the message context, and by setting the value of the context property to `True` from a pipeline component. When this property is set to `True`, the end point manager places the message that failed during mapping in the suspended queue and continues to process remaining messages in the interchange.  
   
- The following code sets the value of the **SuspendMessageOnFailure** property to True.  
+ The following code sets the value of the **SuspendMessageOnMappingFailure** property to True.  
   
 ```  
   


### PR DESCRIPTION
There are 3 ways the property is named in this article. SuspendMessageOnMappingFailure is the correct one.