### PR TITLE
chore: Remove en-us from docs.microsoft.com links

### DIFF
--- a/biztalk/index.md
+++ b/biztalk/index.md
@@ -29,7 +29,7 @@ ms.author: mandia
                             <div class="card">
                                 <div class="cardImageOuter">
                                     <div class="cardImage">
-                                        <img src="https://docs.microsoft.com/en-us/media/common/i_config-tools.svg" alt="" />
+                                        <img src="https://docs.microsoft.com/media/common/i_config-tools.svg" alt="" />
                                     </div>
                                 </div>
                                 <div class="cardText">
@@ -48,7 +48,7 @@ ms.author: mandia
                             <div class="card">
                                 <div class="cardImageOuter">
                                     <div class="cardImage">
-                                        <img src="https://docs.microsoft.com/en-us/media/common/i_whats-new.svg" alt="" />
+                                        <img src="https://docs.microsoft.com/media/common/i_whats-new.svg" alt="" />
                                     </div>
                                 </div>
                                 <div class="cardText">
@@ -67,7 +67,7 @@ ms.author: mandia
                             <div class="card">
                                 <div class="cardImageOuter">
                                     <div class="cardImage">
-                                        <img src="https://docs.microsoft.com/en-us/media/common/i_learn-about.svg" alt="" />
+                                        <img src="https://docs.microsoft.com/media/common/i_learn-about.svg" alt="" />
                                     </div>
                                 </div>
                                 <div class="cardText">
@@ -97,7 +97,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-whats-new.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-whats-new.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -116,7 +116,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-get-started.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-get-started.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -136,7 +136,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-scenarios.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-scenarios.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -156,7 +156,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-b2b.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-b2b.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -180,7 +180,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-adapters-accelerators.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-adapters-accelerators.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -200,7 +200,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-stated-adapters-built-in-adapters.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-stated-adapters-built-in-adapters.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -220,7 +220,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-adapters-adapter-pack.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-adapters-adapter-pack.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -241,7 +241,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-adapters-file-act.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-adapters-file-act.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -261,7 +261,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-adapters-hl7.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-adapters-hl7.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -282,7 +282,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-adapters-rosetta.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-adapters-rosetta.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -302,7 +302,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-adapters-swift.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-adapters-swift.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -325,7 +325,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztallk-get-started-adapters-host-system.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztallk-get-started-adapters-host-system.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -349,7 +349,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-announcements-integrate-2017.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-announcements-integrate-2017.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -370,7 +370,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-get-started-announcements-flipboard.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-get-started-announcements-flipboard.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -395,7 +395,7 @@ ms.author: mandia
                                                 <div class="card" style="min-height:100px;">
                                                     <div class="cardImageOuter" style="width:auto !important;">
                                                         <div class="cardImage">
-                                                            <img alt="" src="https://docs.microsoft.com/en-us/media/common/i_twitter.svg" />
+                                                            <img alt="" src="https://docs.microsoft.com/media/common/i_twitter.svg" />
                                                         </div>
                                                     </div>
                                                     <div class="cardText">
@@ -414,7 +414,7 @@ ms.author: mandia
                                                 <div class="card" style="min-height:100px;">
                                                     <div class="cardImageOuter" style="width:auto !important;">
                                                         <div class="cardImage">
-                                                            <img alt="" src="https://docs.microsoft.com/en-us/media/common/i_twitter.svg" />
+                                                            <img alt="" src="https://docs.microsoft.com/media/common/i_twitter.svg" />
                                                         </div>
                                                     </div>
                                                     <div class="cardText">
@@ -434,7 +434,7 @@ ms.author: mandia
                                                 <div class="card" style="min-height:100px;">
                                                     <div class="cardImageOuter" style="width:auto !important;">
                                                         <div class="cardImage">
-                                                            <img alt="" src="https://docs.microsoft.com/en-us/media/common/i_twitter.svg" />
+                                                            <img alt="" src="https://docs.microsoft.com/media/common/i_twitter.svg" />
                                                         </div>
                                                     </div>
                                                     <div class="cardText">
@@ -453,7 +453,7 @@ ms.author: mandia
                                                 <div class="card" style="min-height:100px;">
                                                     <div class="cardImageOuter" style="width:auto !important;">
                                                         <div class="cardImage">
-                                                            <img alt="" src="https://docs.microsoft.com/en-us/media/common/i_twitter.svg" />
+                                                            <img alt="" src="https://docs.microsoft.com/media/common/i_twitter.svg" />
                                                         </div>
                                                     </div>
                                                     <div class="cardText">
@@ -472,7 +472,7 @@ ms.author: mandia
                                                 <div class="card" style="min-height:100px;">
                                                     <div class="cardImageOuter" style="width:auto !important;">
                                                         <div class="cardImage">
-                                                            <img alt="" src="https://docs.microsoft.com/en-us/media/common/i_twitter.svg" />
+                                                            <img alt="" src="https://docs.microsoft.com/media/common/i_twitter.svg" />
                                                         </div>
                                                     </div>
                                                     <div class="cardText">
@@ -491,7 +491,7 @@ ms.author: mandia
                                                 <div class="card" style="min-height:100px;">
                                                     <div class="cardImageOuter" style="width:auto !important;">
                                                         <div class="cardImage">
-                                                            <img alt="" src="https://docs.microsoft.com/en-us/media/common/i_twitter.svg" />
+                                                            <img alt="" src="https://docs.microsoft.com/media/common/i_twitter.svg" />
                                                         </div>
                                                     </div>
                                                     <div class="cardText">
@@ -510,7 +510,7 @@ ms.author: mandia
                                                 <div class="card" style="min-height:100px;">
                                                     <div class="cardImageOuter" style="width:auto !important;">
                                                         <div class="cardImage">
-                                                            <img alt="" src="https://docs.microsoft.com/en-us/media/common/i_twitter.svg" />
+                                                            <img alt="" src="https://docs.microsoft.com/media/common/i_twitter.svg" />
                                                         </div>
                                                     </div>
                                                     <div class="cardText">
@@ -555,7 +555,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-partner-training-pluralsight.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-partner-training-pluralsight.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -574,7 +574,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-partner-training-quick-learn.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-partner-training-quick-learn.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -603,7 +603,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-developer-documentation-1.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-developer-documentation-1.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -623,7 +623,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-developer-code-samples.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-developer-code-samples.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -643,7 +643,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-developer-codeplex.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-developer-codeplex.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -663,7 +663,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-developer-5-day-course.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-developer-5-day-course.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -694,7 +694,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-whats-new.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-whats-new.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -713,7 +713,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-install-configure.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-install-configure.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -732,7 +732,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-core-documentation.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-core-documentation.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -751,7 +751,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-ole-db-provider.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-ole-db-provider.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -771,7 +771,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-update-center.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-update-center.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -790,7 +790,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-popular-downloads.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-popular-downloads.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -821,7 +821,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-watch-ignite-videos.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-watch-ignite-videos.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -841,7 +841,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-watch-integrate-london.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-watch-integrate-london.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -860,7 +860,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-watch-azure-logic-apps.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-watch-azure-logic-apps.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -880,7 +880,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1">
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-watch-channel9.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-watch-channel9.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">

--- a/his/index.md
+++ b/his/index.md
@@ -28,7 +28,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1"> 
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/his/his-what-is-his.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/his/his-what-is-his.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -47,7 +47,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1"> 
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-whats-new.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-whats-new.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -66,7 +66,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1"> 
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-install-configure.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-install-configure.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -85,7 +85,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1"> 
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-core-documentation.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-core-documentation.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -104,7 +104,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1"> 
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/his/his-security.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/his/his-security.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">
@@ -123,7 +123,7 @@ ms.author: mandia
                                             <div class="card">
                                                 <div class="cardImageOuter">
                                                     <div class="cardImage bgdAccent1"> 
-                                                        <img src="https://docs.microsoft.com/en-us/media/hubs/biztalk/biztalk-host-integration-ole-db-provider.svg" alt="" />
+                                                        <img src="https://docs.microsoft.com/media/hubs/biztalk/biztalk-host-integration-ole-db-provider.svg" alt="" />
                                                     </div>
                                                 </div>
                                                 <div class="cardText">

--- a/technical-reference/toc.yml
+++ b/technical-reference/toc.yml
@@ -452,7 +452,7 @@
               - name: Policies Node
                 href: policies-node.md
               - name: Schemas Node
-                href: https://docs.microsoft.com/en-us/biztalk/core/schemas-node?redirectedfrom=MSDN
+                href: https://docs.microsoft.com/biztalk/core/schemas-node?redirectedfrom=MSDN
               - name: Maps Node
                 href: maps-node.md
               - name: Pipelines Node


### PR DESCRIPTION
To match locale link guidelines. Most of these are image links and probably don't matter as much for the i18n conversion