### PR TITLE
C48202: Escaping example URLs

### DIFF
--- a/biztalk/core/compensation-biztalk-server-sample.md
+++ b/biztalk/core/compensation-biztalk-server-sample.md
@@ -115,9 +115,9 @@ The Compensation sample demonstrates how to use the **Compensate** shape in an o
   
    4.  On the **Orchestrations and Ports** page, click **Next**.  
   
-   5.  On the **Web Service Properties** page, in **Target namespace of web service**, type **http://Microsoft.BizTalk.Samples.Compensation/**, and then click **Next**.  
+   5.  On the **Web Service Properties** page, in **Target namespace of web service**, type `http://Microsoft.BizTalk.Samples.Compensation/`, and then click **Next**.  
   
-   6.  On the **Web Service Project** page, in **Location**, type **http://localhost/CompensationOrchestrationWebServiceProxy**.  
+   6.  On the **Web Service Project** page, in **Location**, type `http://localhost/CompensationOrchestrationWebServiceProxy`.  
   
    7.  Select the **Allow anonymous access to web service** check box.  
   


### PR DESCRIPTION
Hello, @MandiOhlinger,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description of the source issue: Example URLs should be escaped in order to avoid creating a link
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.