### PR TITLE
C51697: Escaping asterisk

### DIFF
--- a/biztalk/core/adapter-registration-file.md
+++ b/biztalk/core/adapter-registration-file.md
@@ -40,7 +40,7 @@ After the custom adapter code has been successfully built it must be registered 
   
  You have two options for specifying the .NET type that implements the adapter receiver, adapter transmitter, and adapter management:  
   
-1. Install the adapter to a folder and specify *TypeName and \*AssemblyPath where \*TypeName is type.FullName of the class and \*AssemblyPath is the path and file name of the assembly.  
+1. Install the adapter to a folder and specify \*TypeName and \*AssemblyPath where \*TypeName is type.FullName of the class and \*AssemblyPath is the path and file name of the assembly.  
   
 2. Install the adapter in the global assembly cache and specify just *TypeName where \*TypeName is type.AssemblyQualifiedName of the class. This is the recommended option.  
   


### PR DESCRIPTION
Hello, @MandiOhlinger,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.