### PR TITLE
Update polling-in-sql-server-using-the-sql-adapter.md

### DIFF
--- a/biztalk/adapters-and-accelerators/adapter-sql/polling-in-sql-server-using-the-sql-adapter.md
+++ b/biztalk/adapters-and-accelerators/adapter-sql/polling-in-sql-server-using-the-sql-adapter.md
@@ -45,7 +45,7 @@ manager: "anneta"
 6. The result sets that are returned as a result of executing the polling statement are sent to the adapter client as the inbound message.  
 
 > [!NOTE]
->  When **UseAmbientTransaction** is set to False, the **PolledDataAvailableStatement** will not be called. The adapter will instead only call the **PollingStatement** directly.
+>  When **UseAmbientTransaction** is set to False, the **PolledDataAvailableStatement** isn't called. Instead, the adapter directly calls the **PollingStatement**.
 
 > [!NOTE]
 >  An XmlPolling operation involves the same steps as the Polling operation.  

--- a/biztalk/adapters-and-accelerators/adapter-sql/polling-in-sql-server-using-the-sql-adapter.md
+++ b/biztalk/adapters-and-accelerators/adapter-sql/polling-in-sql-server-using-the-sql-adapter.md
@@ -1,7 +1,7 @@
 ---
 title: "Polling in SQL Server using the SQL adapter | Microsoft Docs"
 ms.custom: ""
-ms.date: "06/08/2017"
+ms.date: "01/18/2019"
 ms.prod: "biztalk-server"
 ms.reviewer: ""
 
@@ -11,7 +11,7 @@ ms.topic: "article"
 ms.assetid: c31b3cda-c05e-46db-827b-6c47a53d1a3a
 caps.latest.revision: 19
 author: "MandiOhlinger"
-ms.author: "mandia"
+ms.author: "mandia,niklase"
 manager: "anneta"
 ---
 # Polling in SQL Server using the SQL adapter
@@ -43,7 +43,10 @@ manager: "anneta"
 5. The adapter clients can use the **PollWhileDataFound** binding property to ignore the polling interval, and continuously poll data, as and when available.  
   
 6. The result sets that are returned as a result of executing the polling statement are sent to the adapter client as the inbound message.  
-  
+
+> [!NOTE]
+>  When **UseAmbientTransaction** is set to False, the **PolledDataAvailableStatement** will not be called. The adapter will instead only call the **PollingStatement** directly.
+
 > [!NOTE]
 >  An XmlPolling operation involves the same steps as the Polling operation.  
   


### PR DESCRIPTION
Added this clarification
Note: When UseAmbientTransaction is set to False, the PolledDataAvailableStatement will not be called. The adapter will instead only call the PollingStatement directly.