### PR TITLE
C59290: Adding bold asterisks

### DIFF
--- a/biztalk/core/how-to-configure-the-sso-tickets.md
+++ b/biztalk/core/how-to-configure-the-sso-tickets.md
@@ -56,7 +56,7 @@ For more information about tickets and tickets validation, see [SSO Tickets](../
 1. Open a command prompt (Start menu > type **command prompt** > select **Command Prompt**).
 
     > [!TIP]
-    >  On a system that supports User Account Control (UAC), you may need to open the command prompt with Administrative privileges (right-click **Command Prompt** > **Run as administrator).
+    >  On a system that supports User Account Control (UAC), you may need to open the command prompt with Administrative privileges (right-click **Command Prompt** > **Run as administrator**).
   
 2. At the command line, go to the Enterprise Single Sign-On installation directory. The default installation directory is `\Program Files\Common Files\Enterprise Single Sign-On`. For example, enter: 
 


### PR DESCRIPTION
Hello, @MandiOhlinger,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Missing asterisks are preventing bold type tag to be properly rendered. Therefore plain asterisks are shown on live publishing pages. 

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.