### PR TITLE
C101229: Remove spaces to render bold format correctly in Loc pages

### DIFF
--- a/biztalk/core/walkthrough-flat-file-disassembly-using-a-header-and-trailer.md
+++ b/biztalk/core/walkthrough-flat-file-disassembly-using-a-header-and-trailer.md
@@ -72,7 +72,7 @@ Before generating schemas, you need to create a test file.
   
     The file can have one or more ERROR records.  
   
-     **-- OR --  **
+     **-- OR --**
   
      Copy the following sample data into the new file. The last line contains a trailing linefeed:
   


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Closing bold asterisks should be next to last bold word