### PR TITLE
C101229: Escaping asterisk that should be plaint text

### DIFF
--- a/biztalk/core/overview-of-the-bam-development-process.md
+++ b/biztalk/core/overview-of-the-bam-development-process.md
@@ -56,7 +56,7 @@ This topic describes the development process and the database and tables that st
   
     -   Update the data items in the record.  
   
-    -   End the activity and move the record to the BAM_\<*activity name*\*\>_completed table.  
+    -   End the activity and move the record to the BAM_\<*activity name*\>_completed table.  
   
 ## Where BAM Data Is Stored  
  BAM provides the EventObservation namespace that contains the EventStream classes that are used to handle BAM events.  

--- a/biztalk/core/overview-of-the-bam-development-process.md
+++ b/biztalk/core/overview-of-the-bam-development-process.md
@@ -56,7 +56,7 @@ This topic describes the development process and the database and tables that st
   
     -   Update the data items in the record.  
   
-    -   End the activity and move the record to the BAM_\<*activity name**\>_completed table.  
+    -   End the activity and move the record to the BAM_\<*activity name*\*\>_completed table.  
   
 ## Where BAM Data Is Stored  
  BAM provides the EventObservation namespace that contains the EventStream classes that are used to handle BAM events.  


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Not escaped asterisks break format in localized pages
@MandiOhlinger FYI