### PR TITLE
 C101229: Escaping asterisk that should be plaint text

### DIFF
--- a/biztalk/core/how-to-disable-a-user-mapping.md
+++ b/biztalk/core/how-to-disable-a-user-mapping.md
@@ -40,7 +40,7 @@ You can disable a user mapping when you want to turn off all operations associat
   
 2. At the command line, go to the Enterprise Single Sign-On installation directory. The default installation directory is *\<drive\>*:\Program Files\Common Files\Enterprise Single Sign-On.  
   
-3. Type **ssoclient –disablemapping *\<application name\>**<em>, where *\<application name\></em> is the name of the affiliate application you want to remove the user mapping for.  
+3. Type **ssoclient –disablemapping \*\<application name\>**<em>, where *\<application name\></em> is the name of the affiliate application you want to remove the user mapping for.  
   
    > [!NOTE]
    >  On a system that supports User Account Control (UAC), you may need to run the tool with Administrative privileges.  

--- a/biztalk/core/how-to-disable-a-user-mapping.md
+++ b/biztalk/core/how-to-disable-a-user-mapping.md
@@ -23,24 +23,24 @@ You can disable a user mapping when you want to turn off all operations associat
   
  When you disable a user mapping, it will appear as (D) *\<domain\>\\<username\>* when you list the user mappings.  
   
-### To disable a user mapping using the administration utility  
+## Disable a user mapping using the administration utility  
   
 1. On the **Start** menu, click **Run**, and then type **cmd**.  
   
 2. At the command line, go to the Enterprise Single Sign-On installation directory. The default installation directory is *\<drive\>*:\Program Files\Common Files\Enterprise Single Sign-On.  
   
-3. Type **ssomanage –disablemapping *\<domain\>*\\*\<username\> \<application name\>**<em>, where *\<domain\></em> is the Windows domain for the user account, and *\<username\>* is the Windows user name for which you want to disable the credentials, and *\<application name\>* is the name of the affiliate application you want to remove the user mapping for.  
+3. Type **ssomanage –disablemapping \<*domain*\>\\<*username*\> \<*application name*\>**, where \<*domain*\> is the Windows domain for the user account, and *\<username\>* is the Windows user name for which you want to disable the credentials, and *\<application name\>* is the name of the affiliate application you want to remove the user mapping for.  
   
    > [!NOTE]
    >  On a system that supports User Account Control (UAC), you may need to run the tool with Administrative privileges.  
   
-### To disable a user mapping using the client utility  
+## Disable a user mapping using the client utility  
   
 1. On the **Start** menu, click **Run**, and then type **cmd**.  
   
 2. At the command line, go to the Enterprise Single Sign-On installation directory. The default installation directory is *\<drive\>*:\Program Files\Common Files\Enterprise Single Sign-On.  
   
-3. Type **ssoclient –disablemapping \*\<application name\>**<em>, where *\<application name\></em> is the name of the affiliate application you want to remove the user mapping for.  
+3. Type **ssoclient –disablemapping \<*application name*\>**, where \<*application name*\> is the name of the affiliate application you want to remove the user mapping for.  
   
    > [!NOTE]
    >  On a system that supports User Account Control (UAC), you may need to run the tool with Administrative privileges.  


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: Not escaped asterisks break format in localized pages
@MandiOhlinger FYI