### PR TITLE
C101229: Escaping asterisk that should be displayed in live pages

### DIFF
--- a/biztalk/adapters-and-accelerators/accelerator-swift/disassembling-inbound-batches.md
+++ b/biztalk/adapters-and-accelerators/accelerator-swift/disassembling-inbound-batches.md
@@ -64,7 +64,7 @@ The SWIFT disassembler is able to inbound debatching in which it processes or di
   
   `[BH] ([MH] SI [MT])* [BT]`
   
-  The brackets ( `[ ]` ) indicate that the part is optional. The asterisk (**\\\***)indicates that the block is repeatable. Whoever builds the message batch must use the message header (*<em>MH</em>*) and trailer (*<em>MT</em>*) consistently in each repetition of (`[MH] SI [MT]`).  
+  The brackets ( `[ ]` ) indicate that the part is optional. The asterisk (\*\) indicates that the block is repeatable. Whoever builds the message batch must use the message header (*<em>MH</em>*) and trailer (*<em>MT</em>*) consistently in each repetition of (`[MH] SI [MT]`).  
   
   The SWIFT disassembler is able to process any inbound batch that obeys the above structure, because each part in the structure conforms to a flat-file schema. However, if you do not use the optional batch header/trailer and message header/trailer, the message will not conform to those schemas. As a result, a batch containing only consecutive SWIFT messages will have the Batch Header Schema, Batch Trailer Schema, Message Header Schema, and Message Trailer Schema properties set to "None".  
 

--- a/biztalk/adapters-and-accelerators/accelerator-swift/disassembling-inbound-batches.md
+++ b/biztalk/adapters-and-accelerators/accelerator-swift/disassembling-inbound-batches.md
@@ -64,7 +64,7 @@ The SWIFT disassembler is able to inbound debatching in which it processes or di
   
   `[BH] ([MH] SI [MT])* [BT]`
   
-  The brackets ( `[ ]` ) indicate that the part is optional. The asterisk (**\\***)indicates that the block is repeatable. Whoever builds the message batch must use the message header (*<em>MH</em>*) and trailer (*<em>MT</em>*) consistently in each repetition of (`[MH] SI [MT]`).  
+  The brackets ( `[ ]` ) indicate that the part is optional. The asterisk (**\\\***)indicates that the block is repeatable. Whoever builds the message batch must use the message header (*<em>MH</em>*) and trailer (*<em>MT</em>*) consistently in each repetition of (`[MH] SI [MT]`).  
   
   The SWIFT disassembler is able to process any inbound batch that obeys the above structure, because each part in the structure conforms to a flat-file schema. However, if you do not use the optional batch header/trailer and message header/trailer, the message will not conform to those schemas. As a result, a batch containing only consecutive SWIFT messages will have the Batch Header Schema, Batch Trailer Schema, Message Header Schema, and Message Trailer Schema properties set to "None".  
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Un-escaped asterisks are breaking display format in localized pages
@MandiOhlinger