### PR TITLE
C101237: Escaping mock URL

### DIFF
--- a/biztalk/adapters-and-accelerators/adapter-sql/basic-sql-server-data-types.md
+++ b/biztalk/adapters-and-accelerators/adapter-sql/basic-sql-server-data-types.md
@@ -53,7 +53,7 @@ This topic describes how the [!INCLUDE[adaptersql](../../includes/adaptersql-md.
 |Time|Duration|Timespan|-|  
 |Timestamp|Base64Binary|Byte[]|-|  
 |Tinyint|UnsignedByte|Byte|-|  
-|Uniqueidentifier|{http://schemas.microsoft.com/2003/10/Serialization/}:guid|Guid|-|  
+|Uniqueidentifier|{http:\//schemas.microsoft.com/2003/10/Serialization/}:guid|Guid|-|  
 |Varbinary|Base64Binary|Byte[]|-|  
 |Varbinary(Max)|Base64Binary|Byte[]|-|  
 |Varchar|String|String|-|  


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: All hyperlinks are mock hyperlinks and should not be rendered. Please consider adding a backslash on all hyperlinks to prevent link rendering