### PR TITLE
Found a misspelled word and fixed it

### DIFF
--- a/biztalk/core/using-business-activity-monitoring.md
+++ b/biztalk/core/using-business-activity-monitoring.md
@@ -26,7 +26,7 @@ Business Activity Monitoring (BAM) provides visibility into business processes i
   
 -   [Install and Configure BAM](../core/installing-and-configuring-bam.md)  
   
--   [Implementg BAM Solutions](../core/implementing-bam-solutions.md)  
+-   [Implementing BAM Solutions](../core/implementing-bam-solutions.md)  
   
 -   [BAM Dynamic Infrastructure](../core/bam-dynamic-infrastructure.md)  
   


### PR DESCRIPTION
The link title for Implementing BAM Solutions had implementing spelled wrong - "Implementg". I entered a fix for this.