### PR TITLE
Update limitations-of-biztalk-adapter-for-oracle-database.md

### DIFF
--- a/biztalk/adapters-and-accelerators/adapter-oracle-database/limitations-of-biztalk-adapter-for-oracle-database.md
+++ b/biztalk/adapters-and-accelerators/adapter-oracle-database/limitations-of-biztalk-adapter-for-oracle-database.md
@@ -22,7 +22,6 @@ manager: "anneta"
   
 - Barring some exceptions, the [!INCLUDE[adapteroracle_short](../../includes/adapteroracle-short-md.md)] is compatible with the previous release of the adapters. For a list of changes that has happened since the last release, see [Key Features in BizTalk Adapter for Oracle Database](../../adapters-and-accelerators/adapter-oracle-database/key-features-in-biztalk-adapter-for-oracle-database.md).  
   
-- The [!INCLUDE[adapteroracle_short](../../includes/adapteroracle-short-md.md)] does not support XML Types.  
   
 - The SQLEXECUTE operation does not return values for OUT or IN OUT parameters to procedures, functions, or packages. For this reason, you must invoke procedures, functions, and packages by using the dedicated operations that the [!INCLUDE[adapteroracle_short](../../includes/adapteroracle-short-md.md)] exposes for these Oracle artifacts.  
   


### PR DESCRIPTION
BizTalk 2016 never had this constraint. 
CUs were released for 2013 and 2013R2 in year 2014 to address this issue. 
We need the document to be updates.