### PR TITLE
Update installation-known-issues.md

### DIFF
--- a/biztalk/adapters-and-accelerators/accelerator-hl7/installation-known-issues.md
+++ b/biztalk/adapters-and-accelerators/accelerator-hl7/installation-known-issues.md
@@ -23,10 +23,15 @@ Useful information that may help you avoid installation problems.
 - Basic components of [!INCLUDE[btsBizTalkServerNoVersion](../../includes/btsbiztalkservernoversion-md.md)], including Enterprise Single Sign-On (SSO), Group, and Runtime, should be configured.  
   
 - The user installing and configuring BTAHL7 must be a member of the BizTalk Administrators group, and a member of the Administrators group on the SQL Server where the BTAHL7 data is stored.
+
+- The default host should be configured as a FILE receive handler.
   
 ## SQL Server mixed mode not supported  
 The [!INCLUDE[btaBTAHL7NoNumber](../../includes/btabtahl7nonumber-md.md)] does not support SQL Server in mixed mode.  
   
+## Installation succeeds but the BatchControlLocation receive location does not get created. 
+This indicates that the default host is not configured as a FILE receive handler.  During install popup with message "Error while creating receive location for outbound batching" will be shown.  
+
 ## Repair does not work from uninstall/change  
 If user access control (UAC) is enabled, and you try to repair your installation using the control panel, the repair fails. 
 

--- a/biztalk/adapters-and-accelerators/accelerator-hl7/installation-known-issues.md
+++ b/biztalk/adapters-and-accelerators/accelerator-hl7/installation-known-issues.md
@@ -1,5 +1,6 @@
 ---
 title: "Installation known issues | Microsoft Docs"
+description: See the known issues when installing the HL7 accelerator in BizTalk Server.
 ms.custom: ""
 ms.date: "06/08/2017"
 ms.prod: "biztalk-server"
@@ -12,7 +13,7 @@ ms.assetid: b2f80ff9-b37c-49f8-8250-fcf3cec4c0fc
 caps.latest.revision: 2
 author: "MandiOhlinger"
 ms.author: "mandia"
-manager: "anneta"
+manager: "dougeby"
 ---
 # Installation known issues
 Useful information that may help you avoid installation problems.  

--- a/biztalk/core/event-hubs-adapter.md
+++ b/biztalk/core/event-hubs-adapter.md
@@ -10,7 +10,7 @@ ms.suite: ""
 ms.tgt_pltfrm: ""
 ms.topic: "article"
 author: "MandiOhlinger"
-ms.author: "plarsen"
+ms.author: "valthom"
 manager: "anneta"
 ---
 
@@ -56,7 +56,7 @@ Your event hub is now created, and you have the connection strings you need to s
 
     When finished, your properties look similar to the following: 
 
-    ![Endpoint properties](../core/media/event-hub-endpoint-properties.png)
+    ![Sample namespace, name, partition key, and authentication properties in the Event Hub adapter send port endpoint properties in BizTalk Server](../core/media/event-hub-endpoint-properties.png)
 
 
 5. Optional. Configure the **Message** properties. The **Namespace for User Defined Message Properties** value represents the namespace for context properties mapped to Event Hubs message properties.  This can be achieved using a property schema.
@@ -111,7 +111,7 @@ You can use a simple File receive port and location to send messages to your Azu
 
     When finished, your properties look similar to the following: 
 
-    ![Endpoint properties](../core/media/event-hub-endpoint-receive-properties.png)
+    ![Sample namespace, name, consumer group, and authentication properties in the Event Hub adapter receive location endpoint properties in BizTalk Server](../core/media/event-hub-endpoint-receive-properties.png)
 
 5. Configure the **Checkpoint** properties. This adapter uses an Azure blob storage account to reliably read events using a checkpoint, and resume from a restart. 
 


### PR DESCRIPTION
If the default host is not configured as a file receive handler, the HL7 installation will show popup "Error while creating receive location for outbound batching" and will not create the receive location (even though it will succeed).