### PR TITLE
Fix to broken link for "Create the SSIS Catalog"

### DIFF
--- a/biztalk/install-and-config-guides/set-up-and-install-prerequisites-for-biztalk-server-2020.md
+++ b/biztalk/install-and-config-guides/set-up-and-install-prerequisites-for-biztalk-server-2020.md
@@ -266,7 +266,7 @@ If you use BAM, BizTalk Server requires SSIS Catalog to be created. If you don't
 
 **SEE ALSO** : More on [SSIS Catalog](https://docs.microsoft.com/sql/integration-services/catalog/ssis-catalog).
 
-**For specific steps to create the SSIS Catalog, see**: [Create the SSIS Catalog](https://docs.microsoft.com/en-us/sql/integration-services/catalog/ssis-catalog?view=sql-server-ver15#create-the-ssis-catalog).
+**For specific steps to create the SSIS Catalog, see**: [Create the SSIS Catalog](https://docs.microsoft.com/sql/integration-services/catalog/ssis-catalog#create-the-ssis-catalog).
 
 ## Install WinSCP (optional)
 

--- a/biztalk/install-and-config-guides/set-up-and-install-prerequisites-for-biztalk-server-2020.md
+++ b/biztalk/install-and-config-guides/set-up-and-install-prerequisites-for-biztalk-server-2020.md
@@ -266,7 +266,7 @@ If you use BAM, BizTalk Server requires SSIS Catalog to be created. If you don't
 
 **SEE ALSO** : More on [SSIS Catalog](https://docs.microsoft.com/sql/integration-services/catalog/ssis-catalog).
 
-**For specific steps to create the SSIS Catalog, see**: [Create the SSIS Catalog](https://docs.microsoft.com/sql/integration-services/create-the-ssis-catalog).
+**For specific steps to create the SSIS Catalog, see**: [Create the SSIS Catalog](https://docs.microsoft.com/en-us/sql/integration-services/catalog/ssis-catalog?view=sql-server-ver15#create-the-ssis-catalog).
 
 ## Install WinSCP (optional)
 


### PR DESCRIPTION
Link was this (which now gives 404 error):
https://docs.microsoft.com/en-us/sql/integration-services/create-the-ssis-catalog

Updated to this.
https://docs.microsoft.com/en-us/sql/integration-services/catalog/ssis-catalog?view=sql-server-ver15#create-the-ssis-catalog