### PR TITLE
Fix alt-text-bad-value warnings

### DIFF
--- a/biztalk/esb-toolkit/overview-of-the-soa-biztalk-management-point.md
+++ b/biztalk/esb-toolkit/overview-of-the-soa-biztalk-management-point.md
@@ -19,7 +19,7 @@ The BizTalk Management Point natively integrates with SOA Service Manager and Wo
   
  Figure 1 shows the SOA Service Manager Web application displaying the Workbench page for an example application. The left-side tree view allows users to navigate through the applications and services installed within BizTalk Server, and the right-side pane allows users to view application details, operations, access ports, categories, rules, and monitoring information.  
   
- ![Ch9&#45;SOAServiceManager](../esb-toolkit/media/ch9-soaservicemanager.jpg "Ch9-SOAServiceManager")  
+ ![Screenshot of the Workbench page of the SOA Service Manager, which shows the available monitoring features.](../esb-toolkit/media/ch9-soaservicemanager.jpg "Ch9-SOAServiceManager")  
   
  **Figure 1**  
   

--- a/biztalk/esb-toolkit/portal-faults-page.md
+++ b/biztalk/esb-toolkit/portal-faults-page.md
@@ -17,7 +17,7 @@ manager: "anneta"
 # Portal Faults Page
 Figure 1 shows the Faults page. This page displays the main properties of each fault, and it provides sorting and filtering capabilities that support detailed analysis of faults over a range of criteria, such as error type and time. A link for each fault allows you to view more details in the Fault Message Viewer.  
   
- ![FaultsPage](../esb-toolkit/media/faultspage.gif "FaultsPage")  
+ ![Screenshot showing the Faults page of the ESB Management Portal.](../esb-toolkit/media/faultspage.gif "Faults page")  
   
  **Figure 1**  
   

--- a/biztalk/esb-toolkit/repairing-and-resubmitting-a-message.md
+++ b/biztalk/esb-toolkit/repairing-and-resubmitting-a-message.md
@@ -21,7 +21,7 @@ To repair and resubmit a failed message, use the Faults page of the ESB Manageme
   
 1.  Locate the desired fault message on the [Portal Faults Page](../esb-toolkit/portal-faults-page.md) page of the ESB Management Portal. Use the filtering capabilities on the Faults page to search for a specific message. Leave any of the controls empty to retrieve all messages. Note that filtering on a very large fault database may take several seconds to display the appropriate results. Figure 1 illustrates the Faults page.  
   
-     ![FaultsPage](../esb-toolkit/media/faultspage.gif "FaultsPage")  
+     ![Screenshot showing the Faults page of the ESB Management Portal.](../esb-toolkit/media/faultspage.gif "Faults page")  
   
      **Figure 1**  
   

--- a/biztalk/install-and-config-guides/troubleshoot-known-issues-biztalk-install-setup.md
+++ b/biztalk/install-and-config-guides/troubleshoot-known-issues-biztalk-install-setup.md
@@ -240,11 +240,11 @@ Logon fails. Logon failed for user '*BizTalk\BizTalkUser*'
 
 -   Pipelines references Schemas.
 
-![bcd_ExistingBizTalkServerSolutionc](../install-and-config-guides/media/bcd_ExistingBizTalkServerSolutionc.gif)
+![Diagram showing the state of a sample BizTalk Server solution before a user redeploys the Maps project.](../install-and-config-guides/media/bcd_ExistingBizTalkServerSolutionc.gif)
 
 If the user redeploys the Maps project using the default Visual Studio project settings, the Orch1, Orch2, and Pipeline artifacts vanish, as shown in the following figure.
 
-![bcd_BizTalkSolutionWLostArtifactsc](../install-and-config-guides/media/bcd_BizTalkSolutionWLostArtifactsc.gif)
+![Diagram showing the state of a sample BizTalk Server solution after a user redeploys the Maps project by using the default Visual Studio project settings.](../install-and-config-guides/media/bcd_BizTalkSolutionWLostArtifactsc.gif)
 
  Redeploying Maps is a two-step process of undeploying the currently deployed Maps.dll assembly, and then deploying the new Maps.dll file. Visual Studio performs these steps automatically as part of the redeployment process.
 

--- a/biztalk/technical-guides/key-performance-indicators.md
+++ b/biztalk/technical-guides/key-performance-indicators.md
@@ -34,7 +34,7 @@ This topic provides test results that the BizTalk Server product group observed 
   
  **Percentage of BizTalk Server and SQL Server CPU utilization**  
   
- ![M&#45;SingleMsgBox](../technical-guides/media/m-singlemsgbox.gif "M-SingleMsgBox")  
+ ![Diagram showing the percentage of BizTalk Server and SQL Server CPU utilization. The scenario is messaging only, with a single message box.](../technical-guides/media/m-singlemsgbox.gif "M-SingleMsgBox")  
   
 ### Messaging scenario, BizTalk Server and SQL Server scale-out – BizTalk and SQL KPI  
  This test was performed to determine the effectiveness of scaling out the SQL Server tier by adding four MessageBox databases. In this scenario, adding up to two computers running BizTalk Server enabled a maximum sustainable throughput of 2,790 messages per second. This was 118% higher than the maximum obtainable throughput when using only a single MessageBox. Beyond this point, adding more processing power to the BizTalk Server tier degraded performance in a similar fashion to the single MessageBox scenario.  
@@ -43,21 +43,21 @@ This topic provides test results that the BizTalk Server product group observed 
   
  **Percentage of BizTalk Server and SQL Server CPU utilization**  
   
- ![M&#45;MultipleMsgBox](../technical-guides/media/m-multiplemsgbox.gif "M-MultipleMsgBox")  
+ ![Diagram showing the percentage of BizTalk Server and SQL Server CPU utilization. The scenario is messaging only, with multiple message boxes.](../technical-guides/media/m-multiplemsgbox.gif "M-MultipleMsgBox")  
   
 ### Orchestration scenario, BizTalk Server scale-out – SQL Server and BizTalk Server KPI  
  Adding a second computer running BizTalk Server does not show a significant impact on the  overall throughput. The load on the BizTalk Server CPU decreases by 23 percent. The CPU for SQL Server increases from 66.5 percent to 68.5 percent when an additional computer running BizTalk Server is added.  
   
  **Percentage of BizTalk Server and SQL Server CPU utilization**  
   
- ![O&#45;SingleMsgBox](../technical-guides/media/o-singlemsgbox.gif "O-SingleMsgBox")  
+ ![Diagram showing the percentage of BizTalk Server and SQL Server CPU utilization. The scenario is orchestration only, with a single message box.](../technical-guides/media/o-singlemsgbox.gif "O-SingleMsgBox")  
   
 ### Orchestration scenario, BizTalk Server and SQL Server scale-out – SQL Server and BizTalk Server KPI  
  This test was performed to determine the effectiveness of scaling out both the BizTalk Server and SQL Server tier by adding more computers running BizTalk Server and more MessageBox databases for the Orchestration scenario. In this scenario, adding up to two computers running BizTalk Server enabled a maximum sustainable throughput of 1,487 orchestrations per second. This was 116% higher than the maximum obtainable result against a single MessageBox. Scaling out to four MessageBox databases on separate SQL Server computers accommodates increased throughput due to additional processing power and the ability to distribute database load across multiple MessageBox databases. This tactic also relieves contention on shared tables, which was a bottleneck in the single MessageBox environment. As with the Messaging scenario, increasing the number of MessageBox databases and distributing these across dedicated SQL instances enables the addition of several BizTalk Server computers to the BizTalk Server group.  
   
  **Percentage of BizTalk Server and SQL Server CPU utilization**  
   
- ![O&#45;MultipleMsgBox](../technical-guides/media/o-multiplemsgbox.gif "O-MultipleMsgBox")  
+ ![Diagram showing the percentage of BizTalk Server and SQL Server CPU utilization. The scenario is orchestration only, with multiple message boxes.](../technical-guides/media/o-multiplemsgbox.gif "O-MultipleMsgBox")  
   
 ## See Also  
  [Scaling a Production BizTalk Server Environment](../technical-guides/scaling-a-production-biztalk-server-environment.md)


### PR DESCRIPTION
Ripple 3 validation cleanup for alt-text-bad-value warnings by using meaningful text for image alt-text.