### PR TITLE
Fix duplicate H2s - 1

### DIFF
--- a/his/esso/issoconfigstore-setconfiginfo.md
+++ b/his/esso/issoconfigstore-setconfiginfo.md
@@ -15,11 +15,12 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # ISSOConfigStore::SetConfigInfo
-The **SetConfigInf**o method sets the configuration information in the config store.  
+
+The **SetConfigInfo** method sets the configuration information in the config store.  
   
 ## Syntax  
   
-```cpp#  
+```cpp  
   
 HRESULT SetConfigInfo(  
 BSTR bstrApplication,  
@@ -37,7 +38,8 @@ ppbConfigInfo As IPropertyBag
 )  
 ```  
   
-## Remarks  
+## Parameters
+  
  `bstrApplication`  
  [in]  String containing the external application name.  
   
@@ -56,10 +58,11 @@ ppbConfigInfo As IPropertyBag
  `ppbConfigInfo`  
  [in]  Contains a pointer to a property bag containing the config info as name/value pairs.  
   
-## Return Values  
- This method does not return a value.  
+## Return Values
   
- The method returns an **HRESULT**. Possible values include, but are not limited to, those in the following table.  
+This method does not return a value.  
+  
+The method returns an **HRESULT**. Possible values include, but are not limited to, those in the following table.  
   
 |Return code|Description|  
 |-----------------|-----------------|  
@@ -67,20 +70,21 @@ ppbConfigInfo As IPropertyBag
 |E_ACCESSDENIED|Access denied.|  
 |E_INVALIDARG|Invalid argument.|  
   
-## Remarks  
- This method can be used for originally creating the config info or for updating the config info.  
+## Remarks
   
- If the config info does not already exist, all properties of the config info, as defined by the field info for the specified application, must be provided.  
+This method can be used for originally creating the config info or for updating the config info.  
   
- If the config info does already exist, a property within the config info can be missing. Only properties that are provided will be updated. At least one property must be provided.  
+If the config info does not already exist, all properties of the config info, as defined by the field info for the specified application, must be provided.  
   
- Note that due to the use of the Single Sign-On (SSO) store, the first property cannot be masked.  
+If the config info does already exist, a property within the config info can be missing. Only properties that are provided will be updated. At least one property must be provided.  
   
- If the ***bstrSSOServer*** parameter is NULL, the SSO server location is obtained from the registry. If not available in the registry, the local computer will be used.  
+Note that due to the use of the Single Sign-On (SSO) store, the first property cannot be masked.  
+  
+If the ***bstrSSOServer*** parameter is NULL, the SSO server location is obtained from the registry. If not available in the registry, the local computer will be used.  
   
 ## Example  
   
-```  
+```csharp
   
 ConfigStore  
 bstrApplication  
@@ -89,7 +93,8 @@ ppbConfigInfo
   
 ```  
   
-## See Also  
- [ISSOConfigStore::GetConfigInfo](../esso/issoconfigstore-getconfiginfo.md)   
- [ISSOConfigStore Interface (COM)](../esso/issoconfigstore-interface-com.md)   
- [Programming with Enterprise Single Sign-On](../esso/programming-with-enterprise-single-sign-on.md)
+## See Also
+
+[ISSOConfigStore::GetConfigInfo](../esso/issoconfigstore-getconfiginfo.md)   
+[ISSOConfigStore Interface (COM)](../esso/issoconfigstore-interface-com.md)   
+[Programming with Enterprise Single Sign-On](../esso/programming-with-enterprise-single-sign-on.md)

--- a/technical-reference/add-resources-dialog-box.md
+++ b/technical-reference/add-resources-dialog-box.md
@@ -13,11 +13,9 @@ f1_keywords:
 
 # Add Resources Dialog Box
 
- 
-
 Use the **Add Resources** dialog box to add assemblies, scripts, bindings, COM objects, and other resources to an application.
 
-## UIElement List
+The following table describes the UIElements in the **Add Resources** dialog box.
 
 <table>
 <thead>
@@ -59,7 +57,7 @@ Use the **Add Resources** dialog box to add assemblies, scripts, bindings, COM o
 
 The **Options** tab displays special configuration for the resource you have selected in **Selected files to add**.
 
-## UIElement List
+The following table lists the UIElements in the **Options** tab and what they are used for.
 
 <table>
 <thead>
@@ -88,12 +86,11 @@ The **Options** tab displays special configuration for the resource you have sel
 </tbody>
 </table>
 
-
 ## Dependencies Tab
 
 The **Dependencies** tab appears only when **Assembly** or **BizTalk Assembly** is selected in the **File type** list on the **Options** tab. It displays information about other files on which the selected resource has a dependency.
 
-## UIElement List
+The following table lists the UIElements in the **Dependencies** tab and what they are used for.
 
 <table>
 <thead>
@@ -118,8 +115,6 @@ The **Dependencies** tab appears only when **Assembly** or **BizTalk Assembly** 
 </tbody>
 </table>
 
-
 ## See Also
 
 [Understanding BizTalk Application Deployment and Management](https://msdn.microsoft.com/library/aa560022\(v=bts.80\))
-

--- a/technical-reference/application-properties-dialog-box.md
+++ b/technical-reference/application-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Application Properties Dialog Box
 
- 
-
 Use the **Application Properties** window to set one application as the default and to reference other applications.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -47,7 +45,7 @@ Use the **Application Properties** window to set one application as the default 
 
 ## References Tab
 
-## UIElement List
+The following table lists the UIElements in the **References** tab and what they are used for.
 
 <table>
 <thead>
@@ -76,7 +74,6 @@ Use the **Application Properties** window to set one application as the default 
 </tbody>
 </table>
 
-
 ## See Also
 
 [How to Install a BizTalk Application](https://msdn.microsoft.com/library/aa577503\(v=bts.80\))  
@@ -84,4 +81,3 @@ Use the **Application Properties** window to set one application as the default 
 [Importing BizTalk Applications, Bindings, and Policies](https://msdn.microsoft.com/library/aa560565\(v=bts.80\))  
 [How to Import a BizTalk Application](https://msdn.microsoft.com/library/aa560132\(v=bts.80\))  
 [How to Export a BizTalk Application](https://msdn.microsoft.com/library/aa577804\(v=bts.80\))
-

--- a/technical-reference/group-properties-dialog-box.md
+++ b/technical-reference/group-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Group Properties Dialog Box
 
- 
-
 Use the **Group Properties** window to view or modify BizTalk Group properties.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -68,10 +66,9 @@ Use the **Group Properties** window to view or modify BizTalk Group properties.
 </tbody>
 </table>
 
-
 ## Databases Tab
 
-## UIElement List
+The following table lists the UIElements in the **Databases** tab and what they are used for.
 
 <table>
 <thead>
@@ -88,10 +85,9 @@ Use the **Group Properties** window to view or modify BizTalk Group properties.
 </tbody>
 </table>
 
-
 ## Certificate Tab
 
-## UIElement List
+The following table lists the UIElements in the **Certificate** tab and what they are used for.
 
 <table>
 <thead>
@@ -120,7 +116,6 @@ Use the **Group Properties** window to view or modify BizTalk Group properties.
 </tbody>
 </table>
 
-
 ## See Also
 
 [BizTalk Groups](https://msdn.microsoft.com/library/aa559010\(v=bts.80\))  
@@ -130,4 +125,3 @@ Use the **Group Properties** window to view or modify BizTalk Group properties.
 [How to Modify Group Properties](https://msdn.microsoft.com/library/aa560305\(v=bts.80\))  
 [How to Export Bindings for a BizTalk Group](https://msdn.microsoft.com/library/aa560143\(v=bts.80\))  
 [How to Move a Server from One Group to Another](https://msdn.microsoft.com/library/aa559752\(v=bts.80\))
-

--- a/technical-reference/host-properties-dialog-box.md
+++ b/technical-reference/host-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Host Properties Dialog Box
 
- 
-
 Use the **Host Properties** window to view the common properties of the selected send handler.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -60,10 +58,9 @@ Use the **Host Properties** window to view the common properties of the selected
 </tbody>
 </table>
 
-
 ## Certificates Tab
 
-## UIElement List
+The following table lists the UIElements in the **Certificates** tab and what they are used for.
 
 <table>
 <thead>
@@ -92,7 +89,6 @@ Use the **Host Properties** window to view the common properties of the selected
 </tbody>
 </table>
 
-
 ## See Also
 
 [Hosts](https://msdn.microsoft.com/library/aa578695\(v=bts.80\))  
@@ -101,4 +97,3 @@ Use the **Host Properties** window to view the common properties of the selected
 [How to Create a New Host](https://msdn.microsoft.com/library/aa561079\(v=bts.80\))  
 [How to Delete a Host](https://msdn.microsoft.com/library/aa561590\(v=bts.80\))  
 [Minimum Security User Rights](https://msdn.microsoft.com/library/aa559845\(v=bts.80\))
-

--- a/technical-reference/issoconfigstore-setconfiginfo.md
+++ b/technical-reference/issoconfigstore-setconfiginfo.md
@@ -14,13 +14,11 @@ dev_langs:
 
 # ISSOConfigStore::SetConfigInfo
 
- 
-
-The **SetConfigInf**o method sets the configuration information in the config store.
+The **SetConfigInfo** method sets the configuration information in the config store.
 
 ## Syntax
 
-``` c++
+```cpp
   
 HRESULT SetConfigInfo(  
 BSTR bstrApplication,  
@@ -29,7 +27,7 @@ IPropertyBag* ppbConfigInfo
 );  
 ```
 
-``` vb
+```vb
   
 SetConfigInfo(  
 bstrApplication As BSTR,  
@@ -38,7 +36,7 @@ ppbConfigInfo As IPropertyBag
 )  
 ```
 
-## Remarks
+## Parameters
 
 `bstrApplication`  
 \[in\] String containing the external application name.
@@ -87,7 +85,6 @@ The method returns an **HRESULT**. Possible values include, but are not limited 
 </tbody>
 </table>
 
-
 ## Remarks
 
 This method can be used for originally creating the config info or for updating the config info.
@@ -102,7 +99,7 @@ If the ***bstrSSOServer*** parameter is NULL, the SSO server location is obtaine
 
 ## Example
 
-```C#
+```csharp
   
 ConfigStore  
 bstrApplication  
@@ -116,4 +113,3 @@ ppbConfigInfo
 [ISSOConfigStore::GetConfigInfo](issoconfigstore-getconfiginfo.md)  
 [ISSOConfigStore Interface (COM)](issoconfigstore-interface-com.md)  
 [Programming with Enterprise Single Sign-On](https://msdn.microsoft.com/library/aa704508\(v=bts.80\))
-

--- a/technical-reference/message-details-properties-dialog-box.md
+++ b/technical-reference/message-details-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Message Details Properties Dialog Box
 
- 
-
 Use the **Message Details Properties** window to view details of messages in the message box. You cannot edit messages or message properties, but you can turn on message tracking and save the message to another location. The maximum message part size that the **Message Details Properties** window can display is one megabyte (MB); the complete message may be larger than 1 MB, but no single part may be. If a message part is too large to be displayed in the message viewer, you must open the message part using a third-party program. The same window is used for message routing failure reports, in which case, the window title will be "Routing failure report for Message \<Message GUID\>."
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -83,7 +81,6 @@ Use the **Message Details Properties** window to view details of messages in the
 </tr>
 </tbody>
 </table>
-
 
 ## Context Tab
 
@@ -153,7 +150,7 @@ The BizTalk Server engine uses Message tracking properties internally to preserv
 
 ## Message Parts Tab
 
-## UIElement List
+The following table lists the UIElements in the **Message Parts** tab and what they are used for.
 
 <table>
 <thead>
@@ -186,7 +183,6 @@ The BizTalk Server engine uses Message tracking properties internally to preserv
 </tbody>
 </table>
 
-
 ## Body Tab
 
 You use the **Body** tab to view messages in either text or binary format. Ability to view the message body is controlled by role-based access; if you do not have the required privileges to view the message, you will see a message to that effect. The **Body** tab has two subordinate tabs, which you select on the right-hand side of the window; these are the **Text** tab and the **Binary** tab.
@@ -203,13 +199,12 @@ Click the **Binary** tab to view the message in binary form.
 
 Use the **File** menu to track or save messages, or to exit from the **Message Details** window. The **File** menu displays the following options:
 
-  - **Save Message**. Click to display the **Save Message** dialog box.
+- **Save Message**. Click to display the **Save Message** dialog box.
 
-  - **Track Message**. Click to turn on message tracking for the displayed message. A confirmation window appears that requires you to confirm the tracking request. If the message is no longer in the Message Box (terminated or completed), an error message informs you that the message is no longer available.
+- **Track Message**. Click to turn on message tracking for the displayed message. A confirmation window appears that requires you to confirm the tracking request. If the message is no longer in the Message Box (terminated or completed), an error message informs you that the message is no longer available.
 
-  - **Exit**. Click to close the **Message Details Properties** window.
+- **Exit**. Click to close the **Message Details Properties** window.
 
 ## See Also
 
 [Viewing Tracked Message and Instance Data](https://msdn.microsoft.com/library/aa561587\(v=bts.80\))
-

--- a/technical-reference/modify-resources-dialog-box.md
+++ b/technical-reference/modify-resources-dialog-box.md
@@ -13,11 +13,9 @@ f1_keywords:
 
 # Modify Resources Dialog Box
 
- 
-
 Use the **Modify Resources** dialog box to modify options for assemblies, scripts, bindings, COM objects, and other resources and their properties that have been added to an application, or to replace these resources with updated versions bearing the same name.
 
-## UIElement List
+The following table describes the UIElements in the **Modify Resources** dialog box.
 
 <table>
 <thead>
@@ -50,12 +48,11 @@ Use the **Modify Resources** dialog box to modify options for assemblies, script
 </tbody>
 </table>
 
-
 ## Options Tab
 
 The **Options** tab displays special configuration for the resource you have selected in **Selected files to add**.
 
-## UIElement List
+The following table lists the UIElements in the **Options** tab and what they are used for.
 
 <table>
 <thead>
@@ -80,12 +77,11 @@ The **Options** tab displays special configuration for the resource you have sel
 </tbody>
 </table>
 
-
 ## Dependencies Tab
 
 The **Dependencies** tab appears only when **Assembly** or **BizTalk Assembly** is selected in the **File type** list on the **Options** tab. It displays information about other files on which the selected resource has a dependency.
 
-## UIElement List
+The following table lists the UIElements in the **Dependencies** tab and what they are used for.
 
 <table>
 <thead>
@@ -110,8 +106,6 @@ The **Dependencies** tab appears only when **Assembly** or **BizTalk Assembly** 
 </tbody>
 </table>
 
-
 ## See Also
 
 [Understanding BizTalk Application Deployment and Management](https://msdn.microsoft.com/library/aa560022\(v=bts.80\))
-

--- a/technical-reference/orchestration-properties-dialog-box.md
+++ b/technical-reference/orchestration-properties-dialog-box.md
@@ -13,15 +13,13 @@ f1_keywords:
 
 # Orchestration Properties Dialog Box
 
- 
-
 Use the **Orchestration Properties** window to view and configure information about the orchestration you have selected in the details pane.
 
 ## General Tab
 
 The name and assembly information on the **General** tab are created when you create the orchestration in Microsoft Visual Studio. You can add information to the **Description** box at any time.
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -46,10 +44,9 @@ The name and assembly information on the **General** tab are created when you cr
 </tbody>
 </table>
 
-
 ## Bindings Tab
 
-## UIElement List
+The following table lists the UIElements in the **Bindings** tab and what they are used for.
 
 <table>
 <thead>
@@ -70,10 +67,9 @@ The name and assembly information on the **General** tab are created when you cr
 </tbody>
 </table>
 
-
 ## Tracking Tab
 
-## UIElement List
+The following table lists the UIElements in the **Tracking** tab and what they are used for.
 
 <table>
 <thead>
@@ -114,10 +110,8 @@ The name and assembly information on the **General** tab are created when you cr
 </tbody>
 </table>
 
-
 ## See Also
 
 [Creating Orchestrations](https://msdn.microsoft.com/library/aa577489\(v=bts.80\))  
 [About Orchestrations](https://msdn.microsoft.com/library/aa578451\(v=bts.80\))  
 [How to Enlist an Orchestration](https://msdn.microsoft.com/library/aa578153\(v=bts.80\))
-

--- a/technical-reference/party-properties-dialog-box.md
+++ b/technical-reference/party-properties-dialog-box.md
@@ -11,13 +11,11 @@ mtps_version: v=BTS.80
 
 # Party Properties Dialog Box
 
- 
-
 Use the **Party Properties** window to set up and edit trading partners or backend applications to interact with a business process.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -50,10 +48,9 @@ Use the **Party Properties** window to set up and edit trading partners or backe
 </tbody>
 </table>
 
-
 ## Send Ports Tab
 
-## UIElement List
+The following table lists the UIElements in the **Send Ports** tab and what they are used for.
 
 <table>
 <thead>
@@ -82,10 +79,9 @@ Use the **Party Properties** window to set up and edit trading partners or backe
 </tbody>
 </table>
 
-
 ## Certificate Tab
 
-## UIElement List
+The following table lists the UIElements in the **Certificate** tab and what they are used for.
 
 <table>
 <thead>
@@ -113,4 +109,3 @@ Use the **Party Properties** window to set up and edit trading partners or backe
 </tr>
 </tbody>
 </table>
-

--- a/technical-reference/pipeline-properties-dialog-box.md
+++ b/technical-reference/pipeline-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Pipeline Properties Dialog Box
 
- 
-
 You can use the **Pipeline Properties** window to view information on all the pipelines that are deployed in the application, as well as default pipelines that are deployed in every BizTalk installation. You can also configure message tracking options for pipelines. Pipeline properties are configured in Microsoft Visual Studio. The **Description** box is an exception; you can edit it in the **Pipeline Properties** window.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -48,12 +46,11 @@ You can use the **Pipeline Properties** window to view information on all the pi
 </tbody>
 </table>
 
-
 ## Tracking Tab
 
 Pipelines and orchestrations use virtually the same tracking options. You can track promoted message properties from pipelines just as you can from orchestrations.
 
-## UIElement List
+The following table lists the UIElements in the **Tracking** tab and what they are used for.
 
 <table>
 <thead>
@@ -86,7 +83,6 @@ This check box is available only if <strong>Message send and receive events</str
 </tbody>
 </table>
 
-
 ## See Also
 
 [About Pipelines, Stages, and Components](https://msdn.microsoft.com/library/aa577959\(v=bts.80\))  
@@ -94,4 +90,3 @@ This check box is available only if <strong>Message send and receive events</str
 [Investigating Orchestration, Port, and Message Failures](https://msdn.microsoft.com/library/aa560126\(v=bts.80\))  
 [Receive Pipelines](https://msdn.microsoft.com/library/aa561803\(v=bts.80\))  
 [Send Pipelines](https://msdn.microsoft.com/library/aa547976\(v=bts.80\))
-

--- a/technical-reference/policy-properties-dialog-box.md
+++ b/technical-reference/policy-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Policy Properties Dialog Box
 
- 
-
 Use the **Policy Properties** window to view the rule sets that have been added to the application and to configure tracking options. Policy properties are defined in the Microsoft Business Rules Composer.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -48,10 +46,9 @@ Use the **Policy Properties** window to view the rule sets that have been added 
 </tbody>
 </table>
 
-
 ## Tracking Tab
 
-## UIElement List
+The following table lists the UIElements in the **Tracking** tab and what they are used for.
 
 <table>
 <thead>
@@ -80,14 +77,9 @@ Use the **Policy Properties** window to view the rule sets that have been added 
 </tbody>
 </table>
 
-
-
 > [!NOTE]
 > <P>You can view tracked rules and policies during runtime using the queries on the Group Hub page.</P>
-
-
 
 ## See Also
 
 [Importing BizTalk Applications, Bindings, and Policies](https://msdn.microsoft.com/library/aa560565\(v=bts.80\))
-

--- a/technical-reference/receive-location-properties-dialog-box.md
+++ b/technical-reference/receive-location-properties-dialog-box.md
@@ -13,15 +13,13 @@ f1_keywords:
 
 # Receive Location Properties Dialog Box
 
- 
-
 Use the **Receive Location Properties** window to configure receive locations and associate them with receive ports and pipelines.
 
 ## General Tab
 
 Use the **General** tab to associate the receive location with the receive handler of the selected host.
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -74,10 +72,9 @@ Use the **General** tab to associate the receive location with the receive handl
 </tbody>
 </table>
 
-
 ## Schedule Tab
 
-## UIElement List
+The following table lists the UIElements in the **Schedule** tab and what they are used for.
 
 <table>
 <thead>
@@ -110,12 +107,11 @@ Use the **General** tab to associate the receive location with the receive handl
 </tbody>
 </table>
 
-
 ## Certificate Tab
 
 The **Certificate** tab appears only for request-response receive locations.
 
-## UIElement List
+The following table lists the UIElements in the **Certificate** tab and what they are used for.
 
 <table>
 <thead>
@@ -144,7 +140,6 @@ The **Certificate** tab appears only for request-response receive locations.
 </tbody>
 </table>
 
-
 ## See Also
 
 [Receive Locations](https://msdn.microsoft.com/library/aa578407\(v=bts.80\))  
@@ -152,4 +147,3 @@ The **Certificate** tab appears only for request-response receive locations.
 [How to Configure Scheduling for a Receive Location](https://msdn.microsoft.com/library/aa559260\(v=bts.80\))  
 [How to Enable a Receive Location](https://msdn.microsoft.com/library/aa561716\(v=bts.80\))  
 [Minimum Security User Rights](https://msdn.microsoft.com/library/aa559845\(v=bts.80\))
-

--- a/technical-reference/receive-port-properties-dialog-box.md
+++ b/technical-reference/receive-port-properties-dialog-box.md
@@ -13,15 +13,13 @@ f1_keywords:
 
 # Receive Port Properties Dialog Box
 
- 
-
 Use the **Receive Port Properties** window to view the properties of an existing receive port and to create and configure a new receive port.
 
 ## General Tab
 
 Specific properties that are applicable only to two-way ports are hidden for one-way ports.
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -62,10 +60,9 @@ Specific properties that are applicable only to two-way ports are hidden for one
 </tbody>
 </table>
 
-
 ## Receive Locations Tab
 
-## UIElement List
+The following table lists the UIElements in the **Receive Locations** tab and what they are used for.
 
 <table>
 <thead>
@@ -98,12 +95,11 @@ Specific properties that are applicable only to two-way ports are hidden for one
 </tbody>
 </table>
 
-
 ## Inbound Maps Tab
 
 You can use a map to apply an XSL transformation of an inbound message at the receive port without processing the message through an orchestration. You can add more than one map to a receive port, but each map must have a unique source schema.
 
-## UIElement List
+The following table lists the UIElements in the **Inbound Maps** tab and what they are used for.
 
 <table>
 <thead>
@@ -131,13 +127,12 @@ You can use a map to apply an XSL transformation of an inbound message at the re
 </tr>
 </tbody>
 </table>
-
 
 ## Outbound Maps Tab
 
 You can use a map to apply an XSL transformation of a response message sent by the receive port without processing the message through an orchestration. You can add more than one map to a receive port, but each map must have a unique source schema.
 
-## UIElement List
+The following table lists the UIElements in the **Outbound Maps** tab and what they are used for.
 
 <table>
 <thead>
@@ -166,18 +161,14 @@ You can use a map to apply an XSL transformation of a response message sent by t
 </tbody>
 </table>
 
-
 ## Tracking Tab
 
 Message body tracking saves messages after service instances processing is complete. Message property tracking provides a record of promoted properties for each message in the Results list, and enables you to locate a specific message.
 
-
 > [!NOTE]
-> <P>Specific properties that are applicable only to two-way ports are hidden for one-way ports.</P>
+> Specific properties that are applicable only to two-way ports are hidden for one-way ports.
 
-
-
-## UIElement List
+The following table lists the UIElements in the **Tracking** tab and what they are used for.
 
 <table>
 <thead>
@@ -222,8 +213,6 @@ Message body tracking saves messages after service instances processing is compl
 </tbody>
 </table>
 
-
 ## See Also
 
 [How to Create a Receive Port](https://msdn.microsoft.com/library/aa559206\(v=bts.80\))
-

--- a/technical-reference/schema-properties-dialog-box.md
+++ b/technical-reference/schema-properties-dialog-box.md
@@ -13,15 +13,13 @@ f1_keywords:
 
 # Schema Properties Dialog Box
 
- 
-
 Use the **Schema Properties** window to view detailed properties about the schemas in the project. You can also select properties for tracking and locating messages.
 
 ## General Tab
 
 Schema properties on the **General** tab—typically properties that schemas share with items such as maps and orchestrations—are configured in Microsoft® Visual Studio. The **Description** box is an exception; you can edit it in the **Schema Properties** window.
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -58,10 +56,9 @@ Schema properties on the **General** tab—typically properties that schemas sha
 </tbody>
 </table>
 
-
 ## Schema View Tab
 
-## UIElement List
+The following table lists the UIElements in the **Schema View** tab and what they are used for.
 
 <table>
 <thead>
@@ -78,10 +75,9 @@ Schema properties on the **General** tab—typically properties that schemas sha
 </tbody>
 </table>
 
-
 ## Tracking Tab
 
-## UIElement List
+The following table lists the UIElements in the **Tracking** tab and what they are used for.
 
 <table>
 <thead>
@@ -106,10 +102,8 @@ Schema properties on the **General** tab—typically properties that schemas sha
 </tbody>
 </table>
 
-
 ## See Also
 
 [XML Schemas](https://msdn.microsoft.com/library/aa559121\(v=bts.80\))  
 [Different Types of BizTalk Schemas](https://msdn.microsoft.com/library/aa578053\(v=bts.80\))  
 [Property Schemas](https://msdn.microsoft.com/library/aa561059\(v=bts.80\))
-

--- a/technical-reference/send-port-group-properties-dialog-box.md
+++ b/technical-reference/send-port-group-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Send Port Group Properties Dialog Box
 
- 
-
 You can bind Send Port Groups (SPG) to orchestration ports or use them for Content-based Routing (CBR) just as you can for a single send port.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -56,10 +54,9 @@ You can bind Send Port Groups (SPG) to orchestration ports or use them for Conte
 </tbody>
 </table>
 
-
 ## Filters Tab
 
-## UIElement List
+The following table lists the UIElements in the **Filters** tab and what they are used for.
 
 <table>
 <thead>
@@ -100,7 +97,6 @@ You can bind Send Port Groups (SPG) to orchestration ports or use them for Conte
 </tbody>
 </table>
 
-
 ## See Also
 
 [How to Enlist a Send Port or Send Port Group](https://msdn.microsoft.com/library/aa578592\(v=bts.80\))  
@@ -109,4 +105,3 @@ You can bind Send Port Groups (SPG) to orchestration ports or use them for Conte
 [How to Stop a Send Port or Send Port Group](https://msdn.microsoft.com/library/aa577932\(v=bts.80\))  
 [How to Unenlist a Send Port or Send Port Group](https://msdn.microsoft.com/library/aa559480\(v=bts.80\))  
 [Minimum Security User Rights](https://msdn.microsoft.com/library/aa559845\(v=bts.80\))
-

--- a/technical-reference/send-port-properties-dialog-box.md
+++ b/technical-reference/send-port-properties-dialog-box.md
@@ -14,13 +14,11 @@ f1_keywords:
 
 # Send Port Properties Dialog Box
 
- 
-
 Use the **Send Port Properties** window to create new send ports and to configure and view information about the send port you have selected in the details pane.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -74,9 +72,7 @@ This property is visible only for Solicit-Response ports. <strong>Note:</strong>
 
 ## Transport Advanced Options Tab
 
-Only some of the following properties are available for dynamic send ports.
-
-## UIElement List
+Only some of the following properties in the **Transport Advanced Options** tab are available for dynamic send ports.
 
 <table>
 <thead>
@@ -135,7 +131,7 @@ This check box is available when you select the <strong>Ordered delivery</strong
 
 ## Backup Transport Tab
 
-## UIElement List
+The following table lists the UIElements in the **Backup Transport** tab and what they are used for.
 
 <table>
 <thead>
@@ -189,7 +185,7 @@ This check box is available when you select the <strong>Ordered delivery</strong
 
 The **Inbound Maps** tab is visible only for solicit-response pipelines.
 
-## UIElement List
+The following table lists the UIElements in the **Inbound Maps** tab and what they are used for.
 
 <table>
 <thead>
@@ -218,10 +214,9 @@ The **Inbound Maps** tab is visible only for solicit-response pipelines.
 </tbody>
 </table>
 
-
 ## Outbound Maps Tab
 
-## UIElement List
+The following table lists the UIElements in the **Outbound Maps** tab and what they are used for.
 
 <table>
 <thead>
@@ -250,10 +245,9 @@ The **Inbound Maps** tab is visible only for solicit-response pipelines.
 </tbody>
 </table>
 
-
 ## Filters Tab
 
-## UIElement List
+The following table lists the UIElements in the **Filters** tab and what they are used for.
 
 <table>
 <thead>
@@ -294,10 +288,9 @@ The **Inbound Maps** tab is visible only for solicit-response pipelines.
 </tbody>
 </table>
 
-
 ## Certificate Tab
 
-## UIElement List
+The following table lists the UIElements in the **Certificate** tab and what they are used for.
 
 <table>
 <thead>
@@ -326,10 +319,9 @@ The **Inbound Maps** tab is visible only for solicit-response pipelines.
 </tbody>
 </table>
 
-
 ## Tracking Tab
 
-## UIElement List
+The following table lists the UIElements in the **Tracking** tab and what they are used for.
 
 <table>
 <thead>
@@ -374,7 +366,6 @@ The **Inbound Maps** tab is visible only for solicit-response pipelines.
 </tbody>
 </table>
 
-
 ## See Also
 
 [How to Enlist a Send Port or Send Port Group](https://msdn.microsoft.com/library/aa578592\(v=bts.80\))  
@@ -383,4 +374,3 @@ The **Inbound Maps** tab is visible only for solicit-response pipelines.
 [How to Stop a Send Port or Send Port Group](https://msdn.microsoft.com/library/aa577932\(v=bts.80\))  
 [How to Unenlist a Send Port or Send Port Group](https://msdn.microsoft.com/library/aa559480\(v=bts.80\))  
 [Minimum Security User Rights](https://msdn.microsoft.com/library/aa559845\(v=bts.80\))
-

--- a/technical-reference/service-details-properties-dialog-box.md
+++ b/technical-reference/service-details-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Service Details Properties Dialog Box
 
- 
-
 Use the **Service Details** window to view details relating to properties, error information (if any), and messages of individual service instances selected on a Query page. You can use the \[up arrow\] and \[down arrow\] buttons on each tab to scroll through individual instances in the query and see service instance properties for each.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -89,7 +87,6 @@ Use the **Service Details** window to view details relating to properties, error
 </tbody>
 </table>
 
-
 <table>
 <tbody>
 <tr class="odd">
@@ -98,12 +95,11 @@ Use the **Service Details** window to view details relating to properties, error
 </tbody>
 </table>
 
-
 ## Error Information
 
 If a service instance has failed, the reasons for the failure appear on the **Error Information** tab.
 
-## UIElement List
+The following table lists the UIElements in the **Error Information** tab and what they are used for.
 
 <table>
 <thead>
@@ -140,10 +136,9 @@ If a service instance has failed, the reasons for the failure appear on the **Er
 </tbody>
 </table>
 
-
 ## Messages
 
-## UIElement List
+The following table lists the UIElements in the **Messages** tab and what they are used for.
 
 <table>
 <thead>
@@ -168,10 +163,9 @@ If a service instance has failed, the reasons for the failure appear on the **Er
 </tbody>
 </table>
 
-
 ## Messages Context Menu
 
-## UIElement List
+The following table describes the UIElements in the **Messages** context menu.
 
 <table>
 <thead>
@@ -199,4 +193,3 @@ If a service instance has failed, the reasons for the failure appear on the **Er
 </tr>
 </tbody>
 </table>
-

--- a/technical-reference/service-instance-and-message-instance-states.md
+++ b/technical-reference/service-instance-and-message-instance-states.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Service Instance and Message Instance States
 
- 
-
 Service instance states and message instance states are displayed on the Group Hub page. They convey information about successfully processed messages and instances, failures, and suspensions during a specified time interval. Following is an explanation of each message instance and service instance state.
 
 ## Service Instance States
 
-## UIElement List
+The following table describes the service instance states on the Group Hub page.
 
 <table>
 <colgroup>
@@ -87,7 +85,7 @@ Note that when you suspend a scheduled instance and then resume it, the instance
 
 ## Message Instance States
 
-## UIElement List
+The following table describes the message instance states on the Group Hub page.
 
 <table>
 <colgroup>
@@ -137,8 +135,6 @@ Note that when you suspend a scheduled instance and then resume it, the instance
 </tbody>
 </table>
 
-
 ## See Also
 
 [Viewing Tracked Message and Instance Data](https://msdn.microsoft.com/library/aa561587\(v=bts.80\))
-

--- a/technical-reference/start-application-dialog-box.md
+++ b/technical-reference/start-application-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Start Application Dialog Box
 
- 
-
 Use the **Start Application** dialog box to start all dependent artifacts and applications in one transaction.
 
-When you open this dialog box, it is displayed in a collapsed form (without the **Options** or **Referenced Applications** tab visible) if all applications that the current application references are already running. If any of the referenced applications has not already been started when you open this dialog box to start the current application, the dialog box will open with the **Details** portion of the dialog box expanded so that you can see the referenced applications that will also be started.
+When you open this dialog box, it is displayed in a collapsed form (without the **Options** or **Referenced Applications** tab visible) if all applications that the current application references are already running. If any of the referenced applications have not already been started when you open this dialog box to start the current application, the dialog box will open with the **Details** portion of the dialog box expanded so that you can see the referenced applications that will also be started.
 
-## UIElement List
+The following table describes the UIElements in the collapsed form of the **Start Application** dialog box.
 
 <table>
 <thead>
@@ -40,12 +38,11 @@ When you open this dialog box, it is displayed in a collapsed form (without the 
 </tbody>
 </table>
 
-
 ## Options Tab
 
 Each check box represents an application artifact that will start automatically when you start the application unless you specify otherwise. All check boxes are selected by default.
 
-## UIElement List
+The following table describes the UIElements in the **Options** tab.
 
 <table>
 <thead>
@@ -91,7 +88,7 @@ Each check box represents an application artifact that will start automatically 
 
 Each check box represents an application that is referenced by the current one. If the check box next to an application name is selected, that application will start when the current application starts.
 
-## UIElement List
+The following table describes the UIElements in the **Referenced Applications** tab.
 
 <table>
 <thead>
@@ -108,10 +105,8 @@ Each check box represents an application that is referenced by the current one. 
 </tbody>
 </table>
 
-
 ## See Also
 
 [How to Import a BizTalk Application](https://msdn.microsoft.com/library/aa560132\(v=bts.80\))  
 [How to Delete a BizTalk Application from the BizTalk Group](https://msdn.microsoft.com/library/aa577446\(v=bts.80\))  
 [Deploying and Managing BizTalk Applications](https://msdn.microsoft.com/library/aa578693\(v=bts.80\))
-

--- a/technical-reference/stop-application-dialog-box.md
+++ b/technical-reference/stop-application-dialog-box.md
@@ -13,11 +13,9 @@ f1_keywords:
 
 # Stop Application Dialog Box
 
- 
-
 Use the **Stop Application** dialog box to suspend all activation messages, unenlist orchestrations and send ports, disable receive locations, and control running artifact instances.
 
-## UIElement List
+The following table describes the UIElements in the collapsed form of the **Stop Application** dialog box.
 
 <table>
 <thead>
@@ -41,7 +39,7 @@ Use the **Stop Application** dialog box to suspend all activation messages, unen
 
 ## Options Tab
 
-## UIElement List
+The following table describes the UIElements in the **Options** tab.
 
 <table>
 <thead>
@@ -66,12 +64,11 @@ Use the **Stop Application** dialog box to suspend all activation messages, unen
 </tbody>
 </table>
 
-
 ## Referenced Applications Tab
 
 Each check box represents an application that is referenced by the current one. If the check box next to an application name is selected, that application will stop when the current application stops.
 
-## UIElement List
+The following table describes the UIElements in the **Referenced Applications** tab.
 
 <table>
 <thead>
@@ -88,9 +85,7 @@ Each check box represents an application that is referenced by the current one. 
 </tbody>
 </table>
 
-
 ## See Also
 
 [Undeploying BizTalk Applications](https://msdn.microsoft.com/library/aa559800\(v=bts.80\))  
 [How to Delete a BizTalk Application from the BizTalk Group](https://msdn.microsoft.com/library/aa577446\(v=bts.80\))
-

--- a/technical-reference/subscription-details-properties-dialog-box.md
+++ b/technical-reference/subscription-details-properties-dialog-box.md
@@ -13,13 +13,11 @@ f1_keywords:
 
 # Subscription Details Properties Dialog Box
 
- 
-
 The Subscription Details window enables you to examine subscriptions in the BizTalk Server engine.
 
 ## General Tab
 
-## UIElement List
+The following table lists the UIElements in the **General** tab and what they are used for.
 
 <table>
 <thead>
@@ -80,10 +78,9 @@ The Subscription Details window enables you to examine subscriptions in the BizT
 </tbody>
 </table>
 
-
 ## Expression Tab
 
-## UIElement List
+The following table lists the UIElements in the **Expression** tab and what they are used for.
 
 <table>
 <thead>
@@ -112,8 +109,6 @@ The Subscription Details window enables you to examine subscriptions in the BizT
 </tbody>
 </table>
 
-
 ## See Also
 
 [Service Instance and Message Instance States](service-instance-and-message-instance-states.md)
-


### PR DESCRIPTION
Ripple 3 validation cleanup for duplicate H2s.

Instead of using the same H2 heading "UIElements List" for several sections with tables, I converted them to introductory sentences for the table.