### PR TITLE
Fix duplicate H2s - 2

### DIFF
--- a/biztalk/core/activity-management-commands.md
+++ b/biztalk/core/activity-management-commands.md
@@ -201,7 +201,7 @@ bm.exe delete-index -IndexName:Idx1 -Activity:PO
 bm.exe delete-index -IndexName:Idx2 -Activity:PO -Server:S1 -Database:BamPI1  
 ```  
   
-## set-archive Command  
+## get-archive Command  
  **Usage**  
   
  **bm.exe get-archive -Activity:\<activity\> [-Server:\<server\>] [-Database:\<database\>]**  

--- a/biztalk/core/extending-the-flat-file-disassembler-pipeline-component.md
+++ b/biztalk/core/extending-the-flat-file-disassembler-pipeline-component.md
@@ -20,11 +20,10 @@ ms.author: "mandia"
 manager: "anneta"
 ---
 # Extending the Flat File Disassembler Pipeline Component
+
 The following sample illustrates how to create a custom disassembler to parse flat file documents that are UTF-7 encoded. To process UTF-7 documents, the component inherits from the **FFDasmComp** class and then overrides its **GetDataReader** method.  
-  
-## Example  
-  
-```  
+
+```csharp  
 using System;  
 using System.Text;  
 using System.IO;  
@@ -103,13 +102,14 @@ namespace Microsoft.BizTalk.Test
 }  
 ```  
   
-## Example  
- The following example illustrates how to create a custom disassembler for transactional processing of flat file interchanges. It differs from the standard Flat File Disassembler in that it does not produce any disassembled documents until the entire input interchange is completely processed. This component implementation inherits from the **FFDasmComp** class and overrides the **GetNext** method. On the first call to the **GetNext** method, it processes all messages in the interchange, stores them in an **ArrayList**, and returns the first message from the **ArrayList**. On subsequent calls, it returns the next message from the **ArrayList**.  
+## Example
+  
+The following example illustrates how to create a custom disassembler for transactional processing of flat file interchanges. It differs from the standard Flat File Disassembler in that it does not produce any disassembled documents until the entire input interchange is completely processed. This component implementation inherits from the **FFDasmComp** class and overrides the **GetNext** method. On the first call to the **GetNext** method, it processes all messages in the interchange, stores them in an **ArrayList**, and returns the first message from the **ArrayList**. On subsequent calls, it returns the next message from the **ArrayList**.  
   
 > [!NOTE]
->  The implementation of the GetNext() method in the code sample below would not be suitable for the processing of large documents because it retains the entire interchange in memory.  Using this technique for large documents could exhaust memory resources and cause degraded performance or unstable behavior.  
+> The implementation of the GetNext() method in the code sample below would not be suitable for the processing of large documents because it retains the entire interchange in memory.  Using this technique for large documents could exhaust memory resources and cause degraded performance or unstable behavior.  
   
-```  
+```csharp  
 using System;  
 using System.Collections;  
 using System.Runtime.InteropServices;  
@@ -228,5 +228,6 @@ namespace Microsoft.BizTalk.Component
   
 ```  
   
-## See Also  
- [Developing a Disassembling Pipeline Component](../core/developing-a-disassembling-pipeline-component.md)
+## See Also
+  
+[Developing a Disassembling Pipeline Component](../core/developing-a-disassembling-pipeline-component.md)

--- a/biztalk/technical-guides/extending-biztalk-esb-toolkit-capabilities-with-soa-governance.md
+++ b/biztalk/technical-guides/extending-biztalk-esb-toolkit-capabilities-with-soa-governance.md
@@ -191,7 +191,8 @@ The [!INCLUDE[esbToolkit](../includes/esbtoolkit-md.md)] is shipped with [!INCLU
   
    Assign the keyword (**TestKeyword**) back to the version 1 of the service (with the **WSHttpBinding** endpoint).  
   
-## Using the Sentinet BizTalk Server Extensions  
+## Use the Sentinet BizTalk Server Extensions
+  
  In this section, we will look at how the Sentinet BizTalk Extension, together with ESB Resolver, can be used to uniquely identify a service and route the message to that service, with minimal or no changes to the service or the client sending the message. We will test two scenarios:  
   
 - Send a sample message to a service registered in the Sentinet repository (with the keyword attached). Then, change the policy binding for the service using the Sentinet Administrative Console and send another sample message. This scenario demonstrates how changing the service’s security policy neither affects the client application nor the ESB itinerary.  

--- a/his/core/copy-trace-to-file1.md
+++ b/his/core/copy-trace-to-file1.md
@@ -35,9 +35,7 @@ struct copy_trace_to_file {
     unsigned char        reserv4[12];  
 };   
 ```  
-  
-## Remarks  
-  
+
 ## Members  
  *opcode*  
  Supplied parameter. The verb identifying the operation code, SV_COPY_TRACE_TO_FILE.  

--- a/his/core/copy-trace-to-file1.md
+++ b/his/core/copy-trace-to-file1.md
@@ -15,14 +15,15 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # COPY_TRACE_TO_FILE
+
 The **COPY_TRACE_TO_FILE** verb concatenates individual API/link service trace files to form a single file.  
   
- The following structure describes the verb control block (VCB) used by the **COPY_TRACE_TO_FILE** verb.  
+The following structure describes the verb control block (VCB) used by the **COPY_TRACE_TO_FILE** verb.  
   
 ## Syntax  
   
-```  
-  
+```
+
 struct copy_trace_to_file {  
     unsigned short       opcode;  
     unsigned char        opext;  
@@ -36,89 +37,88 @@ struct copy_trace_to_file {
 };   
 ```  
 
-## Members  
- *opcode*  
- Supplied parameter. The verb identifying the operation code, SV_COPY_TRACE_TO_FILE.  
+## Members
   
- *opext*  
- A reserved field.  
+*opcode*  
+Supplied parameter. The verb identifying the operation code, SV_COPY_TRACE_TO_FILE.  
   
- *reserv2*  
- A reserved field.  
+*opext*  
+A reserved field.  
   
- *primary_rc*  
- Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*reserv2*  
+A reserved field.  
   
- *secondary_rc*  
- Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*primary_rc*  
+Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *reserv3*  
- A reserved field.  
+*secondary_rc*  
+Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *file_name*  
- Supplied parameter. Specifies the name of the file to which trace data is to be copied. This parameter is a 64-byte character string, and it can include a path. If the name is fewer than 64 bytes, use spaces to pad it on the right.  
+*reserv3*  
+A reserved field.  
   
- *file_option*  
- Supplied parameter. Specifies the output file copy option:  
+*file_name*  
+Supplied parameter. Specifies the name of the file to which trace data is to be copied. This parameter is a 64-byte character string, and it can include a path. If the name is fewer than 64 bytes, use spaces to pad it on the right.  
+  
+*file_option*  
+Supplied parameter. Specifies the output file copy option:  
   
 - Use SV_NEW to copy the trace only if the specified file does not already exist.  
   
 - Use SV_OVERWRITE to copy the trace to an existing file, overwriting the current data. The size of the file is increased if necessary; and the file is created if it does not already exist.  
   
-  *reserv4*  
-  The address at which supplied data resides.  
+*reserv4*  
+The address at which supplied data resides.  
   
-## Return Codes  
- SV_OK  
- Primary return code; the verb executed successfully.  
+## Return Codes
   
- SV_PARAMETER_CHECK  
- Primary return code; the verb did not execute because of a parameter error.  
+SV_OK  
+Primary return code; the verb executed successfully.  
   
- SV_INVALID_FILE_OPTION  
+SV_PARAMETER_CHECK  
+Primary return code; the verb did not execute because of a parameter error.  
   
- Secondary return code; a value other than SV_NEW or SV_OVERWRITE was specified for **file_option**.  
+SV_INVALID_FILE_OPTION  
+Secondary return code; a value other than SV_NEW or SV_OVERWRITE was specified for **file_option**.  
   
- SV_STATE_CHECK  
- Primary return code; the verb did not execute because it was issued in an invalid state.  
+SV_STATE_CHECK  
+Primary return code; the verb did not execute because it was issued in an invalid state.  
   
- SV_COPY_TRACE_IN_PROGRESS  
+SV_COPY_TRACE_IN_PROGRESS  
+Secondary return code; a previously issued **COPY_TRACE_TO_FILE** verb is still in progress.  
   
- Secondary return code; a previously issued **COPY_TRACE_TO_FILE** verb is still in progress.  
+SV_TRACE_FILE_EMPTY  
+Secondary return code; there is no data in the trace files.  
   
- SV_TRACE_FILE_EMPTY  
+SV_TRACE_NOT_STOPPED  
+Secondary return code; a trace was in progress when the verb was issued.  
   
- Secondary return code; there is no data in the trace files.  
+SV_COMM_SUBSYSTEM_NOT_LOADED  
+Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
   
- SV_TRACE_NOT_STOPPED  
+SV_FILE_ALREADY_EXISTS  
+Primary return code; when the SV_NEW file option was used, the file name specified was the name of an existing file.  
   
- Secondary return code; a trace was in progress when the verb was issued.  
+SV_INVALID_VERB  
+Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
   
- SV_COMM_SUBSYSTEM_NOT_LOADED  
- Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
+SV_INVALID_VERB_SEGMENT  
+Primary return code; the VCB extended beyond the end of the data segment.  
   
- SV_FILE_ALREADY_EXISTS  
- Primary return code; when the SV_NEW file option was used, the file name specified was the name of an existing file.  
+SV_OUTPUT_DEVICE_FULL  
+Primary return code; there is insufficient space on the device where the output file resides. Retry the operation after freeing additional disk space.  
   
- SV_INVALID_VERB  
- Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
+SV_UNEXPECTED_DOS_ERROR  
+Primary return code; one of the following conditions occurred:  
   
- SV_INVALID_VERB_SEGMENT  
- Primary return code; the VCB extended beyond the end of the data segment.  
+- The Microsoft Windows system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.  
   
- SV_OUTPUT_DEVICE_FULL  
- Primary return code; there is insufficient space on the device where the output file resides. Retry the operation after freeing additional disk space.  
+- A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.  
   
- SV_UNEXPECTED_DOS_ERROR  
- Primary return code; one of the following conditions occurred:  
+- A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
   
--   The Microsoft Windows system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.  
+## Remarks
   
--   A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.  
+There are two API/link-service trace files. The files are used alternately; tracing switches from one file to the other when one file is full (larger than 250K). When **COPY_TRACE_TO_FILE** is called, these trace files are concatenated and copied to a single file, the name of which is specified as a parameter to the call.  
   
--   A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
-  
-## Remarks  
- There are two API/link-service trace files. The files are used alternately; tracing switches from one file to the other when one file is full (larger than 250K). When **COPY_TRACE_TO_FILE** is called, these trace files are concatenated and copied to a single file, the name of which is specified as a parameter to the call.  
-  
- API/link-service tracing is stopped before issuing the verb, and restarted after the copy is complete. The trace files are reset when this verb is successfully completed.
+API/link-service tracing is stopped before issuing the verb, and restarted after the copy is complete. The trace files are reset when this verb is successfully completed.

--- a/his/core/define-trace1.md
+++ b/his/core/define-trace1.md
@@ -15,9 +15,10 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # DEFINE_TRACE
+
 The **DEFINE_TRACE** verb enables or disables tracing for specified APIs and controls the amount of tracing.  
   
- The following structure describes the verb control block (VCB) used by the **DEFINE_TRACE** verb.  
+The following structure describes the verb control block (VCB) used by the **DEFINE_TRACE** verb.  
   
 ## Syntax  
   
@@ -58,164 +59,157 @@ struct define_trace {
 };   
 ```  
 
-## Members  
- *opcode*  
- Supplied parameter. The verb identifying the operation code, SV_DEFINE_TRACE.  
+## Members
   
- *opext*  
- A reserved field.  
+*opcode*  
+Supplied parameter. The verb identifying the operation code, SV_DEFINE_TRACE.  
   
- *reserv2*  
- A reserved field.  
+*opext*  
+A reserved field.  
   
- *primary_rc*  
- Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*reserv2*  
+A reserved field.  
   
- *secondary_rc*  
- Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*primary_rc*  
+Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *reserv3*  
- A reserved field.  
+*secondary_rc*  
+Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *dt_set*  
- Supplied parameter. Sets the trace state.  
+*reserv3*  
+A reserved field.  
   
-- Use SV_ON to enable tracing for a particular API if the parameter pertaining to the API (such as **appc** or **comm_serv**) is set to SV_CHANGE.  
+*dt_set*  
+Supplied parameter. Sets the trace state.  
   
+- Use SV_ON to enable tracing for a particular API if the parameter pertaining to the API (such as **appc** or **comm_serv**) is set to SV_CHANGE.    
 - Use SV_OFF to disable tracing for a particular API if the parameter pertaining to the API is set to SV_CHANGE.  
   
-  *appc*  
-  Supplied parameter. Indicates whether tracing of APPC is desired.  
+*appc*  
+Supplied parameter. Indicates whether tracing of APPC is desired.  
   
-- Use SV_CHANGE to enable or disable tracing for APPC, depending on the **dt_set** parameter.  
-  
+- Use SV_CHANGE to enable or disable tracing for APPC, depending on the **dt_set** parameter.    
 - Use SV_IGNORE to leave tracing in its current state for APPC.  
   
-  The allowed values turn bit 0 on or off; bits 1 through 7 are reserved.  
+The allowed values turn bit 0 on or off; bits 1 through 7 are reserved.  
   
-  *reserv4*  
-  A reserved field.  
+*reserv4*  
+A reserved field.  
   
-  *srpi*  
-  Supplied parameter. Indicates whether tracing of SRPI is desired.  
+*srpi*  
+Supplied parameter. Indicates whether tracing of SRPI is desired.  
   
-- Use SV_CHANGE to enable or disable tracing for APPC, depending on the **dt_set** parameter.  
-  
+- Use SV_CHANGE to enable or disable tracing for APPC, depending on the **dt_set** parameter.    
 - Use SV_IGNORE to leave tracing in its current state for APPC.  
   
-  *sdlc*  
-  A reserved field.  
+*sdlc*  
+A reserved field.  
   
-  *tkn_rng_dlc*  
-  A reserved field.  
+*tkn_rng_dlc*  
+A reserved field.  
   
-  *pcnet_dlc*  
-  A reserved field.  
+*pcnet_dlc*  
+ A reserved field.  
   
-  *dft*  
-  A reserved field.  
+*dft*  
+A reserved field.  
   
-  *acdi*  
-  A reserved field.  
+*acdi*  
+A reserved field.  
   
-  *reserv5*  
-  A reserved field.  
+*reserv5*  
+A reserved field.  
   
-  *comm_serv*  
-  Supplied parameter. Indicates whether tracing of COMM_SERV_API is desired.  
+*comm_serv*  
+Supplied parameter. Indicates whether tracing of COMM_SERV_API is desired.  
   
-- Use SV_CHANGE to enable or disable tracing for APPC, depending on the **dt_set** parameter.  
-  
+- Use SV_CHANGE to enable or disable tracing for APPC, depending on the **dt_set** parameter.    
 - Use SV_IGNORE to leave tracing in its current state for APPC.  
   
-  *ehllapi*  
-  A reserved field.  
+*ehllapi*  
+A reserved field.  
   
-  *x25_api*  
-  A reserved field.  
+*x25_api*  
+A reserved field.  
   
-  *x25_dlc*  
-  A reserved field.  
+*x25_dlc*  
+A reserved field.  
   
-  *twinax*  
-  A reserved field.  
+*twinax*  
+A reserved field.  
   
-  reserv6  
-  A reserved field.  
+*reserv6*  
+A reserved field.  
   
-  *lua_api*  
-  A reserved field.  
+*lua_api*  
+A reserved field.  
   
-  *etherand*  
-  A reserved field.  
+*etherand*  
+A reserved field.  
   
-  *subsym*  
-  A reserved field.  
+*subsym*  
+A reserved field.  
   
-  *reserv7*  
-  A reserved field.  
+*reserv7*  
+A reserved field.  
   
-  *reset_trc*  
-  Supplied parameter. Indicates whether the trace file pointer should be reset.  
+*reset_trc*  
+Supplied parameter. Indicates whether the trace file pointer should be reset.  
   
-- Use SV_NO to not reset the trace file pointer to the start of the trace file. Previous trace records are not overwritten.  
-  
+- Use SV_NO to not reset the trace file pointer to the start of the trace file. Previous trace records are not overwritten.    
 - Use SV_YES to reset the trace file pointer to the start of the trace file. Previous trace records are overwritten.  
   
-  *trunc*  
-  Supplied parameter. Specifies the maximum number of bytes for each trace record. Excess bytes are truncated. Set this value to zero if you do not want truncation.  
+*trunc*  
+Supplied parameter. Specifies the maximum number of bytes for each trace record. Excess bytes are truncated. Set this value to zero if you do not want truncation.  
   
-  *strg_size*  
-  A reserved field.  
+*strg_size*  
+A reserved field.  
   
-  *reserv8*  
-  A reserved field.  
+*reserv8*  
+A reserved field.  
   
-  *phys_link*  
-  A reserved field.  
+*phys_link*  
+A reserved field.  
   
-  *reserv9*  
-  A reserved field.  
+*reserv9*  
+A reserved field.  
   
-## Return Codes  
- SV_OK  
- Primary return code; the verb executed successfully.  
+## Return Codes
   
- SV_PARAMETER_CHECK  
- Primary return code; the verb did not execute because of a parameter error.  
+SV_OK  
+Primary return code; the verb executed successfully.  
   
- SV_INVALID_RESET_TRACE  
+SV_PARAMETER_CHECK  
+Primary return code; the verb did not execute because of a parameter error.  
   
- Secondary return code; the **reset_trc** parameter contained an invalid value.  
+SV_INVALID_RESET_TRACE  
+Secondary return code; the **reset_trc** parameter contained an invalid value.  
   
- SV_INVALID_SET  
+SV_INVALID_SET  
+Secondary return code; the **dt_set** parameter contained an invalid value.  
   
- Secondary return code; the **dt_set** parameter contained an invalid value.  
+SV_STATE_CHECK  
+Primary return code; the verb did not execute because it was issued in an invalid state.  
   
- SV_STATE_CHECK  
- Primary return code; the verb did not execute because it was issued in an invalid state.  
+SV_COPY_TRACE_IN_PROGRESS  
+Secondary return code; a previously issued [COPY_TRACE_TO_FILE](../core/copy-trace-to-file1.md) is still in progress. Traces cannot be active while using **DEFINE_TRACE**.  
   
- SV_COPY_TRACE_IN_PROGRESS  
+SV_COMM_SUBSYSTEM_NOT_LOADED  
+Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
   
- Secondary return code; a previously issued [COPY_TRACE_TO_FILE](../core/copy-trace-to-file1.md) is still in progress. Traces cannot be active while using **DEFINE_TRACE**.  
+SV_INVALID_VERB  
+Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
   
- SV_COMM_SUBSYSTEM_NOT_LOADED  
- Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
+SV_INVALID_VERB_SEGMENT  
+Primary return code; the VCB extended beyond the end of the data segment.  
   
- SV_INVALID_VERB  
- Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
+SV_UNEXPECTED_DOS_ERROR  
+Primary return code; one of the following conditions occurred:  
   
- SV_INVALID_VERB_SEGMENT  
- Primary return code; the VCB extended beyond the end of the data segment.  
+- The Microsoft® Windows® system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.    
+- A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.    
+- A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
   
- SV_UNEXPECTED_DOS_ERROR  
- Primary return code; one of the following conditions occurred:  
+## Remarks
   
--   The Microsoft® Windows® system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.  
-  
--   A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.  
-  
--   A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
-  
-## Remarks  
- For information on how to run and use traces, see the appropriate manual for your product.
+For information on how to run and use traces, see the appropriate manual for your product.

--- a/his/core/define-trace1.md
+++ b/his/core/define-trace1.md
@@ -57,9 +57,7 @@ struct define_trace {
     unsigned char        reserv9[56];  
 };   
 ```  
-  
-## Remarks  
-  
+
 ## Members  
  *opcode*  
  Supplied parameter. The verb identifying the operation code, SV_DEFINE_TRACE.  

--- a/his/core/elm-format-for-the-tcp-elm-user-data-programming-model2.md
+++ b/his/core/elm-format-for-the-tcp-elm-user-data-programming-model2.md
@@ -15,10 +15,12 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # ELM Format for the TCP ELM User Data Programming Model
+
 This section describes the format and content of the enhanced listener message (ELM) used by the TCP ELM User Data programming model.  
   
-## ELM Request Message  
- The following table shows the contents of the request message.  
+## ELM Request Message
+  
+The following table shows the contents of the request message.  
   
 |Client in data|  
 |--------------------|  
@@ -27,10 +29,9 @@ This section describes the format and content of the enhanced listener message (
  Client in data  
  35 bytes of data used by the CICS TCP/IP security exit and passed to the Concurrent Server in the transaction initiation message (TIM).  
   
-## Client in data for Microsoft Security Exit format  
- The following code block describes the format of the client in data for the Microsoft security exit.  
+## Client in data for Microsoft Security Exit format
   
-## Syntax  
+The following code block describes the format of the client in data for the Microsoft security exit.  
   
 ```  
 struct CLIENT_IN_DATA {  
@@ -40,10 +41,9 @@ struct CLIENT_IN_DATA {
 } UNALIGNED;  
 ```  
   
-## Client in data for IBM Security Exit format  
- The following code block describes the format of the client in data for the IBM security exit.  
+## Client in data for IBM Security Exit format
   
-## Syntax  
+The following code block describes the format of the client in data for the IBM security exit.  
   
 ```  
 struct CLIENT_IN_DATA2 {  
@@ -54,40 +54,42 @@ struct CLIENT_IN_DATA2 {
 } UNALIGNED;  
 ```  
   
-## ELM Reply Message  
- The following table shows the contents of the reply message.  
+## ELM Reply Message
+  
+The following table shows the contents of the reply message.  
   
 |ELM reply msg length|Formatted field length|Formatted field code|*Data*|  
 |--------------------------|----------------------------|--------------------------|------------|  
 |4|4|1|*0-n*|  
   
 > [!NOTE]
->  The formatted field length, formatted field code, and data can be repeated multiple times in a single message.  
+> The formatted field length, formatted field code, and data can be repeated multiple times in a single message.  
   
- ELM reply msg length  
- The total length of the ELM reply message. This length is the sum of all the lengths of the formatted fields that follow in the message and does not include the length of the ELM reply msg length field itself.  
+*ELM reply msg length*  
+The total length of the ELM reply message. This length is the sum of all the lengths of the formatted fields that follow in the message and does not include the length of the ELM reply msg length field itself.  
   
- Formatted field length  
- The length of the formatted field.  
+*Formatted field length*  
+The length of the formatted field.  
   
- The formatted field length is the sum of the combination of the Formatted field code length and the Data length.  
+The formatted field length is the sum of the combination of the Formatted field code length and the Data length.  
   
- Formatted field code  
- A 1-byte code that describes the information passed from the Concurrent Server back to the client.  
+*Formatted field code*  
+A 1-byte code that describes the information passed from the Concurrent Server back to the client.  
   
- You cannot change the Formatted field code.  
+You cannot change the Formatted field code.  
   
- The field codes are specific to the communication handling between the WIP and HIP TCP Transports and the MSCMTICS, MSHIPLNK and TCP Concurrent Server programs.  
+The field codes are specific to the communication handling between the WIP and HIP TCP Transports and the MSCMTICS, MSHIPLNK and TCP Concurrent Server programs.  
   
- Data  
- 0 or more bytes of information that is associated with a specific formatted field.  
+*Data*  
+0 or more bytes of information that is associated with a specific formatted field.  
   
- You may change the information stored in Data. If you change Data, be sure that you also change the TRM Reply and the Formatted Field Length to the new values.  
+You may change the information stored in Data. If you change Data, be sure that you also change the TRM Reply and the Formatted Field Length to the new values.  
   
- The length of Data is equal to the formatted field length minus the size of the formatted field code.  
+The length of Data is equal to the formatted field length minus the size of the formatted field code.  
   
-## Normal codes  
- The following table shows the meaning of the normal codes.  
+## Normal codes
+  
+The following table shows the meaning of the normal codes.  
   
 |Code|Type|Meaning|  
 |----------|----------|-------------|  
@@ -95,8 +97,9 @@ struct CLIENT_IN_DATA2 {
 |0x02|Info|User Data|  
 |0x07|Info|Execution OK|  
   
-## Error codes  
- The following table shows the meaning of the error codes.  
+## Error codes
+  
+The following table shows the meaning of the error codes.  
   
 |Code|Type|Meaning|  
 |----------|----------|-------------|  
@@ -108,8 +111,9 @@ struct CLIENT_IN_DATA2 {
 |0x09|Error|Execution Failed|  
 |0x0A|Error|Invalid ELM|  
   
- For more information about the format of the TRM, see the TRM definition file at \<drive>:\Program Files\ Microsoft Host Integration Server\System\TIM\MicrosoftTRMDefs.tim. Use Visual Studio to view the file.  
+For more information about the format of the TRM, see the TRM definition file at \<drive>:\Program Files\ Microsoft Host Integration Server\System\TIM\MicrosoftTRMDefs.tim. Use Visual Studio to view the file.  
   
-## See Also  
- [ELM Format for the TCP ELM Link Programming Model](../core/elm-format-for-the-tcp-elm-link-programming-model1.md)   
- [Enhanced Listener CICS Administration](../core/enhanced-listener-cics-administration2.md)
+## See Also
+  
+[ELM Format for the TCP ELM Link Programming Model](../core/elm-format-for-the-tcp-elm-link-programming-model1.md)   
+[Enhanced Listener CICS Administration](../core/enhanced-listener-cics-administration2.md)

--- a/his/core/get-cp-convert-table1.md
+++ b/his/core/get-cp-convert-table1.md
@@ -15,9 +15,10 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # GET_CP_CONVERT_TABLE
+
 The **GET_CP_CONVERT_TABLE** verb creates and returns a 256-byte conversion table to translate character strings from a source code page to a target code page.  
   
- The following structure describes the verb control block (VCB) used by the **GET_CP_CONVERT_TABLE** verb.  
+The following structure describes the verb control block (VCB) used by the **GET_CP_CONVERT_TABLE** verb.  
   
 ## Syntax  
   
@@ -38,132 +39,126 @@ struct get_cp_convert_table {
 };  
 ```  
   
-## Members  
- *opcode*  
- Supplied parameter. The verb identifying the operation code, SV_GET_CP_CONVERT_TABLE.  
+## Members
   
- *opext*  
- A reserved field.  
+*opcode*  
+Supplied parameter. The verb identifying the operation code, SV_GET_CP_CONVERT_TABLE.  
   
- *reserv2*  
- A reserved field.  
+*opext*  
+A reserved field.  
   
- *primary_rc*  
- Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*reserv2*  
+A reserved field.  
   
- *secondary_rc*  
- Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*primary_rc*  
+Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *reserv3*  
- A reserved field.  
+*secondary_rc*  
+Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *source_cp*  
- Supplied parameter. Specifies the source code page from which characters are converted. The allowed code pages (decimal values) are as follows:  
+*reserv3*  
+A reserved field.  
+  
+*source_cp*  
+Supplied parameter. Specifies the source code page from which characters are converted. The allowed code pages (decimal values) are as follows:  
   
 - ASCII 437, 850, 860, 863, 865  
   
 - EBCDIC 037, 273, 277, 278, 280, 284, 285, 297, 500  
   
-  User-defined code pages in the range from 65280 through 65535 are also allowed.  
+User-defined code pages in the range from 65280 through 65535 are also allowed.  
   
-  ASCII code pages are sometimes referred to as PC code pages; EBCDIC code pages are sometimes referred to as host code pages.  
+ASCII code pages are sometimes referred to as PC code pages; EBCDIC code pages are sometimes referred to as host code pages.  
   
-  *target_cp*  
-  Supplied parameter. Specifies the target code page to which characters are converted. For allowed code pages, see the preceding definition for **source_cp**.  
+*target_cp*  
+Supplied parameter. Specifies the target code page to which characters are converted. For allowed code pages, see the preceding definition for **source_cp**.  
   
-  *conv_tbl_addr*  
+*conv_tbl_addr*  
   Supplied parameter. Specifies the address of the buffer to contain the 256-byte conversion table. The buffer must be in a writable segment and long enough to contain the table.  
   
-  *char_not_fnd*  
-  Supplied parameter. Specifies the action to take if a character in the source code page does not exist in the target code page:  
+*char_not_fnd*  
+Supplied parameter. Specifies the action to take if a character in the source code page does not exist in the target code page:  
   
 - Use SV_ROUND_TRIP to store a unique value in the conversion table for each source code page character.  
   
 - Use SV_SUBSTITUTE to store a substitute character (specified by **substitute_char**) in the conversion table.  
   
-  *substitute_char*  
-  Supplied parameter. Specifies the character to store in the conversion table when a character from the source code page has no equivalent in the target code page.  
+*substitute_char*  
+Supplied parameter. Specifies the character to store in the conversion table when a character from the source code page has no equivalent in the target code page.  
   
-## Return Codes  
- SV_OK  
- Primary return code; the verb executed successfully.  
+## Return Codes
   
- SV_PARAMETER_CHECK  
- Primary return code; the verb did not execute because of a parameter error.  
+SV_OK  
+Primary return code; the verb executed successfully.  
   
- SV_INVALID_CHAR_NOT_FOUND  
+SV_PARAMETER_CHECK  
+Primary return code; the verb did not execute because of a parameter error.  
   
- Secondary return code; the **char_not_fnd** parameter contained an invalid value.  
+SV_INVALID_CHAR_NOT_FOUND  
+Secondary return code; the **char_not_fnd** parameter contained an invalid value.  
   
- SV_INVALID_DATA_SEGMENT  
+SV_INVALID_DATA_SEGMENT  
+Secondary return code; the 256-byte area specified for the conversion table extended beyond the segment boundary, or the segment was not writable.  
   
- Secondary return code; the 256-byte area specified for the conversion table extended beyond the segment boundary, or the segment was not writable.  
+SV_INVALID_SOURCE_CODE_PAGE  
+Secondary return code; the code page specified by **source_cp** is not supported.  
   
- SV_INVALID_SOURCE_CODE_PAGE  
+SV_INVALID_TARGET_CODE_PAGE  
+Secondary return code; the code page specified by **target_cp** is not supported.  
   
- Secondary return code; the code page specified by **source_cp** is not supported.  
+SV_COMM_SUBSYSTEM_NOT_LOADED  
+Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
   
- SV_INVALID_TARGET_CODE_PAGE  
+SV_INVALID_VERB  
+Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
   
- Secondary return code; the code page specified by **target_cp** is not supported.  
+SV_INVALID_VERB_SEGMENT  
+Primary return code; the VCB extended beyond the end of the data segment.  
   
- SV_COMM_SUBSYSTEM_NOT_LOADED  
- Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
+SV_UNEXPECTED_DOS_ERROR  
+Primary return code; one of the following conditions occurred:  
   
- SV_INVALID_VERB  
- Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
+- The Microsoft® Windows® system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.  
   
- SV_INVALID_VERB_SEGMENT  
- Primary return code; the VCB extended beyond the end of the data segment.  
+- A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.  
   
- SV_UNEXPECTED_DOS_ERROR  
- Primary return code; one of the following conditions occurred:  
+- A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
   
--   The Microsoft® Windows® system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.  
+## Remarks
   
--   A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.  
+The type A character set consists of:  
   
--   A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
-  
-## Remarks  
- The type A character set consists of:  
-  
-- Uppercase letters.  
-  
+- Uppercase letters.
 - Numerals 0 through 9.  
-  
 - Special characters $, #, @, and space.  
   
-  This character set is supported by a system-supplied type A conversion table.  
+This character set is supported by a system-supplied type A conversion table.  
   
-  The first character of the source string must be an uppercase letter or the special character $, #, or @. Spaces are allowed only in trailing positions. Lowercase ASCII letters are translated to uppercase EBCDIC letters when the direction is ASCII to EBCDIC.  
+The first character of the source string must be an uppercase letter or the special character $, #, or @. Spaces are allowed only in trailing positions. Lowercase ASCII letters are translated to uppercase EBCDIC letters when the direction is ASCII to EBCDIC.  
   
-  The type AE character set consists of:  
+The type AE character set consists of:  
   
 - Uppercase letters.  
-  
 - Lowercase letters.  
-  
 - Numerals 0 through 9.  
-  
 - Special characters $, #, @, period, and space.  
   
-  This character set is supported by a system-supplied type AE conversion table.  
+This character set is supported by a system-supplied type AE conversion table.  
   
-  The first character of the source string can be any character in the character set except the space.  
+The first character of the source string can be any character in the character set except the space.  
   
-  During conversion, embedded blanks (including blanks in the first position) are converted to 0x00. Although such a conversion will complete, CONVERSION_ERROR is returned as the secondary return code, indicating that the CSV library has completed an irreversible conversion on the supplied data.  
+During conversion, embedded blanks (including blanks in the first position) are converted to 0x00. Although such a conversion will complete, CONVERSION_ERROR is returned as the secondary return code, indicating that the CSV library has completed an irreversible conversion on the supplied data.  
   
-  For Windows, a description of COMTBLG should point to the Windows registry under **\SnaBase\Parameters\Client**. For the OS/2 operating system, the directory and file containing the table must be specified by the environment variable COMTBLG. (If the file is not found, the system returns the SV_TABLE_ERROR parameter check.).  
+For Windows, a description of COMTBLG should point to the Windows registry under **\SnaBase\Parameters\Client**. For the OS/2 operating system, the directory and file containing the table must be specified by the environment variable COMTBLG. (If the file is not found, the system returns the SV_TABLE_ERROR parameter check.).  
   
-  The SV_ROUND_TRIP value for **char_not_fnd** is useful only if you build a second conversion table to convert between the same two code pages in the reverse direction. If you specify the SV_ROUND_TRIP value in building both conversion tables, any character translated from one code page to the other and then back will be unchanged.  
+The SV_ROUND_TRIP value for **char_not_fnd** is useful only if you build a second conversion table to convert between the same two code pages in the reverse direction. If you specify the SV_ROUND_TRIP value in building both conversion tables, any character translated from one code page to the other and then back will be unchanged.  
   
-  When using the SV_SUBSTITUTE value for **char_not_fnd**, converting the translated character string back to the original code page will not necessarily re-create the original character string.  
+When using the SV_SUBSTITUTE value for **char_not_fnd**, converting the translated character string back to the original code page will not necessarily re-create the original character string.  
   
-  Use **substitute_char** only if **char_not_fnd** is set to SV_SUBSTITUTE.  
+Use **substitute_char** only if **char_not_fnd** is set to SV_SUBSTITUTE.  
   
-  The value stored in the conversion table is the ASCII value associated with the character. If the table is used for conversion from ASCII to EBCDIC, the character that appears in the converted string is the character associated with the numeric EBCDIC value rather than ASCII.  
+The value stored in the conversion table is the ASCII value associated with the character. If the table is used for conversion from ASCII to EBCDIC, the character that appears in the converted string is the character associated with the numeric EBCDIC value rather than ASCII.  
   
-  For example, if you supply the underscore (*) character (ASCII value F6) while creating an ASCII to EBCDIC conversion table, the character that appears in the converted strings will be 6, the character associated with the value F6 in EBCDIC. To use the \\* character as the substitute character in an ASCII to EBCDIC conversion table, you should supply the value E1 (the value associated with the \_ character in EBCDIC) rather than the actual character.  
+For example, if you supply the underscore (*) character (ASCII value F6) while creating an ASCII to EBCDIC conversion table, the character that appears in the converted strings will be 6, the character associated with the value F6 in EBCDIC. To use the \\* character as the substitute character in an ASCII to EBCDIC conversion table, you should supply the value E1 (the value associated with the \_ character in EBCDIC) rather than the actual character.  
   
-  A code page is a table that associates specific ASCII or EBCDIC values with specific characters. If a character from the source code page does not exist in the target code page, the translated (target) string differs from the original (source) string.
+A code page is a table that associates specific ASCII or EBCDIC values with specific characters. If a character from the source code page does not exist in the target code page, the translated (target) string differs from the original (source) string.

--- a/his/core/get-cp-convert-table1.md
+++ b/his/core/get-cp-convert-table1.md
@@ -38,8 +38,6 @@ struct get_cp_convert_table {
 };  
 ```  
   
-## Remarks  
-  
 ## Members  
  *opcode*  
  Supplied parameter. The verb identifying the operation code, SV_GET_CP_CONVERT_TABLE.  

--- a/his/core/getluareturncode2.md
+++ b/his/core/getluareturncode2.md
@@ -27,8 +27,6 @@ struct LUA_COMMON FAR *vpb,
     unsigned char FAR *buffer_addr );  
 ```  
   
-## Remarks  
-  
 #### Parameters  
  *vpb*  
  Supplied parameter. Specifies the address of the verb control block.  

--- a/his/core/getluareturncode2.md
+++ b/his/core/getluareturncode2.md
@@ -15,39 +15,44 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # GetLuaReturnCode
+
 The **GetLuaReturnCode** function converts the primary and secondary return codes in the verb control block (VCB) to a printable string. This function provides a standard set of error strings for use by logical unit application (LUA) applications.  
   
 ## Syntax  
   
 ```  
   
-        int WINAPI GetLuaReturnCode(   
-struct LUA_COMMON FAR *vpb,    
+int WINAPI GetLuaReturnCode (   
+    struct LUA_COMMON FAR *vpb,    
     UINT buffer_length,            
-    unsigned char FAR *buffer_addr );  
+    unsigned char FAR *buffer_addr 
+);  
 ```  
   
-#### Parameters  
- *vpb*  
- Supplied parameter. Specifies the address of the verb control block.  
+## Parameters
   
- *buffer_length*  
- Supplied parameter. Specifies the length of the buffer pointed to by *buffer_addr*. The recommended length is 256.  
+*vpb*  
+Supplied parameter. Specifies the address of the verb control block.  
   
- *buffer_addr*  
- Supplied/returned parameter. Specifies the address of the buffer that will hold the formatted, null-terminated string.  
+*buffer_length*  
+Supplied parameter. Specifies the length of the buffer pointed to by *buffer_addr*. The recommended length is 256.  
   
-## Return Codes  
- 0x20000001  
- The parameters are invalid; the function could not read from the specified verb control block or could not write to the specified buffer.  
+*buffer_addr*  
+Supplied/returned parameter. Specifies the address of the buffer that will hold the formatted, null-terminated string.  
   
- 0x20000002  
- The specified buffer is too small.  
+## Return Codes
   
- 0x20000003  
- The LUA string library LUAST32.DLL could not be loaded.  
+0x20000001  
+The parameters are invalid; the function could not read from the specified verb control block or could not write to the specified buffer.  
   
-## Remarks  
- The descriptive error string returned in *buffer_addr* does not terminate with a newline character (**\n**).  
+0x20000002  
+The specified buffer is too small.  
   
- The descriptive error strings are contained in LUAST32.DLL and can be customized for different languages.
+0x20000003  
+The LUA string library LUAST32.DLL could not be loaded.  
+  
+## Remarks
+  
+The descriptive error string returned in *buffer_addr* does not terminate with a newline character (**\n**).  
+  
+The descriptive error strings are contained in LUAST32.DLL and can be customized for different languages.

--- a/his/core/link-definition-information2.md
+++ b/his/core/link-definition-information2.md
@@ -27,7 +27,8 @@ typedef struct link_def_info_sect {
 } LINK_DEF_INFO_SECT;  
 ```  
   
-## Members  
+## Members
+  
  link_def_init_sect_len  
  The length of the initial link definition information section, including this parameter, up to the first link definition overlay group. The length does not include any previous information sections.  
   

--- a/his/core/link-definition-information2.md
+++ b/his/core/link-definition-information2.md
@@ -15,9 +15,10 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # Link Definition Information
+
 Link definition information is provided in the **link_def_info_sect** structure as defined below.  
-  
-## Syntax  
+
+## Syntax
   
 ```  
 typedef struct link_def_info_sect {  
@@ -29,18 +30,16 @@ typedef struct link_def_info_sect {
   
 ## Members
   
- link_def_init_sect_len  
- The length of the initial link definition information section, including this parameter, up to the first link definition overlay group. The length does not include any previous information sections.  
+*link_def_init_sect_len*  
+The length of the initial link definition information section, including this parameter, up to the first link definition overlay group. The length does not include any previous information sections.  
   
- num_link_def  
- The number of link definitions returned by the **DISPLAY** verb into your program's buffer. This is the number of times the link definition overlay is repeated.  
+*num_link_def*  
+The number of link definitions returned by the **DISPLAY** verb into your program's buffer. This is the number of times the link definition overlay is repeated.  
   
- total_link_def  
- The total number of link definitions. This number is the same as the number returned in the **num_link_def** member except when APPC has more information about link definitions than it can place in the supplied buffer, in which case this number is larger.  
+*total_link_def*  
+The total number of link definitions. This number is the same as the number returned in the **num_link_def** member except when APPC has more information about link definitions than it can place in the supplied buffer, in which case this number is larger.  
   
- For each link definition, a **link_def_overlay** structure for the link definition is provided as defined below.  
-  
-## Syntax  
+For each link definition, a **link_def_overlay** structure for the link definition is provided as defined below.  
   
 ```  
 typedef struct link_def_overlay {  
@@ -75,185 +74,190 @@ typedef struct link_def_overlay {
   
 ## Defined by IBM ES for OS/2 version 1.0  
   
-## Members  
- link_def_entry_len  
- Size of this link definition entry.  
+The **link_def_overlay** structure as defined by IBM ES for OS/2 version 1.0 contains the following members:
   
- link_name  
- Local logical link station name (EBCDIC).  
+*link_def_entry_len*  
+Size of this link definition entry.  
   
- dlc_name  
- Data link control (DLC) name set to one of the following:  
+*link_name*  
+Local logical link station name (EBCDIC).  
   
- ETHERAND  
-  IBMTRNET  
-  IBMPCNET  
-  SDLC  
-  TWINAX (Not supported by Host Integration Server)  
-  X25DLC  
-  adj_fq_cp_name  
- Fully qualified **cp_name** in adjacent node.  
+*dlc_name*  
+Data link control (DLC) name set to one of the following:  
   
- adj_node_type  
- The adjacent node type (AP_ADJACENT_NN, AP_LEARN, or AP_LEN).  
+- ETHERAND  
+- IBMTRNET  
+- IBMPCNET  
+- SDLC  
+- TWINAX (Not supported by Host Integration Server)  
+- X25DLC
+
+*adj_fq_cp_name*  
+Fully qualified **cp_name** in adjacent node.  
   
- adapter_num  
- DLC adapter number used by this link.  
+*adj_node_type*  
+The adjacent node type (AP_ADJACENT_NN, AP_LEARN, or AP_LEN).  
   
- dest_addr_len  
- Length of the destination adapter address.  
+*adapter_num*  
+DLC adapter number used by this link.  
   
- dest_addr  
- The destination adapter address.  
+*dest_addr_len*  
+Length of the destination adapter address.  
   
- cp_cp_sess_spt  
- Specifies whether the link supports CP-CP sessions.  
+*dest_addr* 
+The destination adapter address.  
   
- preferred_nn_server  
- Indicates if this is the preferred NN server.  
+*cp_cp_sess_spt*  
+Specifies whether the link supports CP-CP sessions.  
   
- auto_act_link  
- Indicates if the link should be automatically activated.  
+*preferred_nn_server*  
+Indicates if this is the preferred NN server.  
   
- tg_number  
- Transmission group number.  
+*auto_act_link*  
+Indicates if the link should be automatically activated.  
   
- lim_res  
- Indicates if this is a limited resource.  
+*tg_number*  
+Transmission group number.  
   
- solicit_sscp_session  
- Indicates whether to solicit an SSCP session.  
+*lim_res* 
+Indicates if this is a limited resource.  
   
- initself  
- Indicates if the node supports receiving INIT_SELF over this link.  
+*solicit_sscp_session*  
+Indicates whether to solicit an SSCP session.  
   
- bind_support  
- Indicates whether BIND support is available.  
+*initself*  
+Indicates if the node supports receiving INIT_SELF over this link.  
   
- ls_role  
- Specifies the link station role.  
+*bind_support*  
+Indicates whether BIND support is available.  
   
- line_type  
- The line type.  
+*ls_role*  
+Specifies the link station role.  
   
- eff_capacity  
- Highest bit rate transmission effective capacity supported.  
+*line_type*  
+The line type.  
   
- conn_cost  
- Relative cost per connection time using this link.  
+*eff_capacity*  
+Highest bit rate transmission effective capacity supported.  
   
- byte_cost  
- Relative cost of transmitting a byte over link.  
+*conn_cost*  
+Relative cost per connection time using this link.  
   
- propagation_delay  
- Indicates amount of time for signal to travel length of link. Set to one of the following:  
+*byte_cost*  
+Relative cost of transmitting a byte over link.  
   
- AP_PROP_DELAY_MINIMUM  
-  AP_PROP_DELAY_LAN  
-  AP_PROP_DELAY_TELEPHONE  
-  AP_PROP_DELAY_PKT_SWITCHED_NET  
-  AP_PROP_DELAY_SATELLITE  
-  AP_PROP_DELAY_MAXIMUM  
-  user_def_1  
- User-defined TG characteristics.  
+*propagation_delay*  
+Indicates amount of time for signal to travel length of link. Set to one of the following:  
   
- user_def_2  
- User-defined TG characteristics.  
+- AP_PROP_DELAY_MINIMUM  
+- AP_PROP_DELAY_LAN  
+- AP_PROP_DELAY_TELEPHONE  
+- AP_PROP_DELAY_PKT_SWITCHED_NET  
+- AP_PROP_DELAY_SATELLITE  
+- AP_PROP_DELAY_MAXIMUM
+
+*user_def_1*  
+User-defined TG characteristics.  
   
- user_def_3  
- User-defined TG characteristics.  
+*user_def_2*  
+User-defined TG characteristics.  
   
- security  
- The security value for this link. Set to one of the following:  
+*user_def_3*  
+User-defined TG characteristics.  
   
- AP_SEC_NONSECURE  
-  AP_SEC_PUBLIC_SWITCHED_NETWORK  
-  AP_SEC_UNDERGROUND_CABLE  
-  AP_SEC_SECURE_CONDUIT  
-  AP_SEC_GUARDED_CONDUIT  
-  AP_SEC_ENCRYPTED  
-  AP_SEC_GUARDED_RADIATION  
+*security*  
+The security value for this link. Set to one of the following:  
+  
+- AP_SEC_NONSECURE  
+- AP_SEC_PUBLIC_SWITCHED_NETWORK  
+- AP_SEC_UNDERGROUND_CABLE  
+- AP_SEC_SECURE_CONDUIT  
+- AP_SEC_GUARDED_CONDUIT  
+- AP_SEC_ENCRYPTED  
+- AP_SEC_GUARDED_RADIATION  
   
 ## Returned by Host Integration Server  
   
-## Members  
- link_def_entry_len  
- Size of this link definition entry.  
+The **link_def_overlay** structure returned by Host Integration Server contains the following members:
   
- link_name  
- Local logical link station name (EBCDIC).  
+*link_def_entry_len*  
+Size of this link definition entry.  
   
- dlc_name  
- Data link control (DLC) name set to one of the following:  
+*link_name*  
+Local logical link station name (EBCDIC).  
   
- IBMTRNET  
-  SDLC  
-  X25DLC  
-  adj_fq_cp_name  
- Fully qualified **cp_name** in adjacent node. Always set to EBCDIC spaces.  
+*dlc_name*  
+Data link control (DLC) name set to one of the following:  
   
- adj_node_type  
- The adjacent node type. Always set to AP_LEN.  
+- IBMTRNET  
+- SDLC  
+- X25DLC  
+
+*adj_fq_cp_name*  
+Fully qualified **cp_name** in adjacent node. Always set to EBCDIC spaces.  
   
- adapter_num  
- DLC adapter number used by this link. Always set to zero.  
+*adj_node_type*  
+The adjacent node type. Always set to AP_LEN.  
   
- dest_addr_len  
- Length of the destination adapter address.  
+*adapter_num*  
+DLC adapter number used by this link. Always set to zero.  
   
- dest_addr  
- The destination adapter address.  
+*dest_addr_len*  
+Length of the destination adapter address.  
   
- cp_cp_sess_spt  
- Specifies whether the link supports CP-CP sessions. Always set to AP_NO.  
+*dest_addr*  
+The destination adapter address.  
   
- preferred_nn_server  
- Indicates if this is the preferred NN server.  
+*cp_cp_sess_spt*  
+Specifies whether the link supports CP-CP sessions. Always set to AP_NO.  
   
- auto_act_link  
- Indicates if the link should be automatically activated.  
+*preferred_nn_server*  
+Indicates if this is the preferred NN server.  
   
- tg_number  
- Transmission group number. Always set to zero.  
+*auto_act_link*  
+Indicates if the link should be automatically activated.  
   
- lim_res  
- Indicates if this is a limited resource.  
+*tg_number*  
+Transmission group number. Always set to zero.  
   
- solicit_sscp_session  
- Indicates whether to solicit an SSCP session.  
+*lim_res*  
+Indicates if this is a limited resource.  
   
- initself  
- Indicates if the node supports receiving INIT_SELF over this link.  
+*solicit_sscp_session*  
+Indicates whether to solicit an SSCP session.  
   
- bind_support  
- Indicates whether BIND support is available.  
+*initself*  
+Indicates if the node supports receiving INIT_SELF over this link.  
   
- ls_role  
- Specifies the link station role.  
+*bind_support*  
+Indicates whether BIND support is available.  
   
- line_type  
- The line type.  
+*ls_role*  
+Specifies the link station role.  
   
- effective_capacity  
- Highest bit rate transmission effective capacity supported. Always set to zero.  
+*line_type*  
+The line type.  
   
- conn_cost  
- Relative cost per connection time using this link. Always set to zero.  
+*effective_capacity*  
+Highest bit rate transmission effective capacity supported. Always set to zero.  
   
- byte_cost  
- Relative cost of transmitting a byte over link. Always set to zero.  
+*conn_cost*  
+Relative cost per connection time using this link. Always set to zero.  
   
- propagation_delay  
- Indicates amount of time for signal to travel length of link. Set to one of the following: Always set to AP_PROP_DELAY_MAXIMUM.  
+*byte_cost*  
+Relative cost of transmitting a byte over link. Always set to zero.  
   
- user_def_1  
- User-defined TG characteristics. Always set to zero.  
+*propagation_delay*  
+Indicates amount of time for signal to travel length of link. Set to one of the following: Always set to AP_PROP_DELAY_MAXIMUM.  
   
- user_def_2  
- User-defined TG characteristics. Always set to zero.  
+*user_def_1*  
+User-defined TG characteristics. Always set to zero.  
   
- user_def_3  
- User-defined TG characteristics. Always set to zero.  
+*user_def_2*  
+User-defined TG characteristics. Always set to zero.  
   
- security  
- The security value for this link. Always set to AP_SEC_NONSECURE.
+*user_def_3*  
+User-defined TG characteristics. Always set to zero.  
+  
+*security*  
+The security value for this link. Always set to AP_SEC_NONSECURE.

--- a/his/core/log-message2.md
+++ b/his/core/log-message2.md
@@ -15,9 +15,10 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # LOG_MESSAGE
+
 For OS/2 only, the **LOG_MESSAGE** verb records a message in the error log file and optionally displays the message on the users screen. This verb is included for compatibility with existing applications.  
   
- The following structure describes the verb control block (VCB) used by the **LOG_MESSAGE** verb.  
+The following structure describes the verb control block (VCB) used by the **LOG_MESSAGE** verb.  
   
 ## Syntax  
   
@@ -38,99 +39,99 @@ struct log_message {
 };  
 ```  
   
-## Remarks  
+## Members
   
-## Members  
- *opcode*  
- Supplied parameter. The verb identifying the operation code, SV_LOG_MESSAGE.  
+*opcode*  
+Supplied parameter. The verb identifying the operation code, SV_LOG_MESSAGE.  
   
- *opext*  
- A reserved field.  
+*opext*  
+A reserved field.  
   
- *reserv2*  
- A reserved field.  
+*reserv2*  
+A reserved field.  
   
- *primary_rc*  
- Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*primary_rc*  
+Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *secondary_rc*  
- Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*secondary_rc*  
+Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *msg_num*  
- Supplied parameter. Specifies the number of the message in the message file specified by **msg_file_name**.  
+*msg_num*  
+Supplied parameter. Specifies the number of the message in the message file specified by **msg_file_name**.  
   
- *origntr_id*  
- Supplied parameter. Specifies the name of the component issuing **LOG_MESSAGE** or an 8-byte, user-supplied string.  
+*origntr_id*  
+Supplied parameter. Specifies the name of the component issuing **LOG_MESSAGE** or an 8-byte, user-supplied string.  
   
- *msg_file_name*  
- Supplied parameter. Specifies the name of the file containing the message to be logged.  
+*msg_file_name*  
+Supplied parameter. Specifies the name of the file containing the message to be logged.  
   
- *msg_act*  
- Supplied parameter. Specifies the action to be taken when processing the message:  
+*msg_act*  
+Supplied parameter. Specifies the action to be taken when processing the message:  
   
 - Use SV_INTRV to log the intervention with a severity level of 12 and display the message on the users screen. The user must press a key to remove the message from the screen.  
   
 - Use SV_NO_INTRV to log the intervention with a severity level of 12 but not display the message.  
   
-  *msg_ins_len*  
-  Supplied parameter. Specifies the length of data to be inserted into the message. Set this parameter to zero if no data is to be inserted.  
+*msg_ins_len*  
+Supplied parameter. Specifies the length of data to be inserted into the message. Set this parameter to zero if no data is to be inserted.  
   
-  msg_ins_ptr  
-  Supplied parameter. Specifies the address of the data to be inserted into the message.  
+*msg_ins_ptr*  
+Supplied parameter. Specifies the address of the data to be inserted into the message.  
   
-  Use this parameter only if **msg_ins_len** is greater than zero.  
+Use this parameter only if **msg_ins_len** is greater than zero.  
   
-## Return Codes  
- SV_OK  
- Primary return code; the verb executed successfully.  
+## Return Codes
   
- SV_PARAMETER_CHECK  
- Primary return code; the verb did not execute because of a parameter error.  
+SV_OK  
+Primary return code; the verb executed successfully.  
   
- SV_INVALID_DATA_SEGMENT  
+SV_PARAMETER_CHECK  
+Primary return code; the verb did not execute because of a parameter error.  
   
- Secondary return code; the data that was to be inserted into the message extended beyond the segment boundary.  
+SV_INVALID_DATA_SEGMENT  
+Secondary return code; the data that was to be inserted into the message extended beyond the segment boundary.  
   
- SV_INVALID_MESSAGE_ACTION  
+SV_INVALID_MESSAGE_ACTION  
+Secondary return code; the **msg_act** parameter contained an invalid value.  
   
- Secondary return code; the **msg_act** parameter contained an invalid value.  
+SV_COMM_SUBSYSTEM_NOT_LOADED  
+Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
   
- SV_COMM_SUBSYSTEM_NOT_LOADED  
- Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
+SV_INVALID_VERB  
+Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
   
- SV_INVALID_VERB  
- Primary return code; the **opcode** parameter did not match the operation code of any verb. No verb executed.  
+SV_INVALID_VERB_SEGMENT  
+Primary return code; the VCB extended beyond the end of the data segment.  
   
- SV_INVALID_VERB_SEGMENT  
- Primary return code; the VCB extended beyond the end of the data segment.  
+SV_UNEXPECTED_DOS_ERROR  
+Primary return code; one of the following conditions occurred:  
   
- SV_UNEXPECTED_DOS_ERROR  
- Primary return code; one of the following conditions occurred:  
+- The Microsoft Windows system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.  
   
--   The Microsoft Windows system encountered an error while processing the verb. The operating system return code was returned through the secondary return code. If the problem persists, contact the system administrator for corrective action.  
+- A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.  
   
--   A CSV was issued from a message loop that was invoked by another application issuing a Windows **SendMessage** function call, rather than the more common Windows **PostMessage** function call. Verb processing cannot take place.  
+- A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
   
--   A CSV was issued when **SendMessage** invoked your application. You can determine whether your application has been invoked with **SendMessage** by using the **InSendMessage** Windows API function call.  
+## Remarks
   
-## Remarks  
- The value for **msg_file_name** must be three characters long. Pad with spaces if necessary. The .MSG extension is added automatically.  
+The value for **msg_file_name** must be three characters long. Pad with spaces if necessary. The .MSG extension is added automatically.  
   
- The total length of **msg_ins_len**, including header information (40 bytes), message text, and inserted data, should not exceed 256 bytes. If the length is greater than 256 bytes, the communication system will attempt to log only the header information and inserted text; the message text will be left out.  
+The total length of **msg_ins_len**, including header information (40 bytes), message text, and inserted data, should not exceed 256 bytes. If the length is greater than 256 bytes, the communication system will attempt to log only the header information and inserted text; the message text will be left out.  
   
- When you create the log message file, you can specify where in the message the additional data is to be inserted. Further information is provided below.  
+When you create the log message file, you can specify where in the message the additional data is to be inserted. Further information is provided below.  
   
- The data for **msg_ins_ptr** consists of a series of up to nine null-terminated strings. (Because IBM OS/2 ES version 1.0 supports only three data strings, you may want to limit the inserted text to three strings to ensure compatibility.)  
+The data for **msg_ins_ptr** consists of a series of up to nine null-terminated strings. (Because IBM OS/2 ES version 1.0 supports only three data strings, you may want to limit the inserted text to three strings to ensure compatibility.)  
   
-## Creating a Message File  
- If you want to create your own message file, you must use the utility MKMSGF.  
+## Creating a Message File
   
- The first three characters of the message number must match the three-character name of the log message file. These three characters are declared at the top of the file as well.  
+If you want to create your own message file, you must use the utility MKMSGF.  
   
- The system finds the message file as follows:  
+The first three characters of the message number must match the three-character name of the log message file. These three characters are declared at the top of the file as well.  
   
--   If you use your own message file, the system assumes the file is in the same directory as your programs executable file.  
+The system finds the message file as follows:  
   
--   If you use the default message file, COM.MSG, the system finds the file automatically, provided the SnaBase for Microsoft Host Integration Server is loaded.  
+- If you use your own message file, the system assumes the file is in the same directory as your programs executable file.  
   
--   If you use the default message file without loading the previously-mentioned software, the system expects DPATH to indicate the path to the message file. This applies only to the Windows version 3.*x* and OS/2 operating systems.
+- If you use the default message file, COM.MSG, the system finds the file automatically, provided the SnaBase for Microsoft Host Integration Server is loaded.  
+  
+- If you use the default message file without loading the previously-mentioned software, the system expects DPATH to indicate the path to the message file. This applies only to the Windows version 3.*x* and OS/2 operating systems.

--- a/his/core/lu-0-to-3-information2.md
+++ b/his/core/lu-0-to-3-information2.md
@@ -15,6 +15,7 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # LU 0 to 3 Information
+
 LU 0 to 3 information is provided in the **lu_0_3_info_sect** structure as defined below.  
   
 ## Syntax  
@@ -26,16 +27,15 @@ typedef struct lu_0_3_info_sect {
 } LU_0_3_ INFO_SECT;  
 ```  
   
-## Members  
- lu_0_3_init_sect_len  
- The length of the initial LU 0 to 3 information section, including this parameter, up to the first link overlay group. The length does not include any previous information sections.  
+## Members
+
+*lu_0_3_init_sect_len*  
+The length of the initial LU 0 to 3 information section, including this parameter, up to the first link overlay group. The length does not include any previous information sections.  
   
- num_lu_0_3s  
- The number of LU groups. This is the number of times the lu_0_3 overlay group is repeated.  
+*num_lu_0_3s*  
+The number of LU groups. This is the number of times the lu_0_3 overlay group is repeated.  
   
- For each configured LU, an **lu_0_3_overlay** structure for the LU is provided as defined below.  
-  
-## Syntax  
+For each configured LU, an **lu_0_3_overlay** structure for the LU is provided as defined below.  
   
 ```  
 typedef struct lu_0_3_overlay {  
@@ -58,124 +58,128 @@ typedef struct lu_0_3_overlay {
   
 ## Defined by IBM ES for OS/2 version 1.0  
   
-## Members  
- lu_0_3_entry_len  
- Size of this LU entry.  
+The **lu_0_3_overlay** structure as defined by IBM ES for OS/2 version 1.0 contains the following members:
   
- access_type  
- The access type (AP_3270 or AP_LUA).  
+*lu_0_3_entry_len*  
+Size of this LU entry.  
   
- lu_type  
- The LU type (AP_LU0, AP_LU1, AP_LU2, or AP_LU3).  
+*access_type*  
+The access type (AP_3270 or AP_LUA).  
   
- lu_daf  
- The network addressable unit of the LU for which the information is displayed.  
+*lu_type*  
+The LU type (AP_LU0, AP_LU1, AP_LU2, or AP_LU3).  
   
- lu_short_name  
- The 1-byte LU short name (ASCII).  
+*lu_daf*  
+The network addressable unit of the LU for which the information is displayed.  
   
- lu_long_name  
- The 8-byte ASCII LU long name.  
+*lu_short_name*  
+The 1-byte LU short name (ASCII).  
   
- session_id  
- The LU-LU session ID.  
+*lu_long_name*  
+The 8-byte ASCII LU long name.  
   
- dlc_name  
- DLC name set to one of the following:  
+*session_id*  
+The LU-LU session ID.  
   
- ETHERAND  
-  IBMTRNET  
-  IBMPCNET  
-  SDLC  
-  TWINAX (Not supported by Host Integration Server)  
-  X25DLC  
-  adapter_num  
- The DLC adapter number for host link.  
+*dlc_name*  
+DLC name set to one of the following:  
   
- dest_addr_len  
- Length of the destination adapter address.  
+- ETHERAND  
+- IBMTRNET  
+- IBMPCNET  
+- SDLC  
+- TWINAX (Not supported by Host Integration Server)  
+- X25DLC 
+
+*adapter_num*  
+The DLC adapter number for host link.  
   
- dest_addr  
- The destination adapter address.  
+*dest_addr_len*  
+Length of the destination adapter address.  
   
- sscp_lu_sess_state  
- Specifies the state of the SSCP-LU session.  
+*dest_addr*  
+The destination adapter address.  
   
- lu_lu_sess_state  
- Specifies the state of the LU-LU session. The state can be one of the following:  
+*sscp_lu_sess_state*  
+Specifies the state of the SSCP-LU session.  
   
- AP_NOT_BOUND  
- The LU-LU session is not bound.  
+*lu_lu_sess_state*  
+Specifies the state of the LU-LU session. The state can be one of the following:  
   
- AP_BOUND  
- The LU-LU session is bound.  
+- AP_NOT_BOUND  
+  The LU-LU session is not bound.  
   
- AP_BINDING  
- The LU-LU session is in the process of binding.  
+- AP_BOUND  
+  The LU-LU session is bound.  
   
- AP_UNBINDING  
- The LU-LU session is in the process of unbinding.  
+- AP_BINDING  
+  The LU-LU session is in the process of binding.  
   
- link_id  
- Name of local logical link station being used.  
+- AP_UNBINDING  
+  The LU-LU session is in the process of unbinding.  
+  
+*link_id*  
+Name of local logical link station being used.  
   
 ## Returned by Host Integration Server  
   
-## Members  
- lu_0_3_entry_len  
- Size of this LU entry.  
+The **lu_0_3_overlay** structure returned by Host Integration Server contains the following members:
   
- access_type  
- The access type (AP_3270 or AP_LUA).  
+*lu_0_3_entry_len*  
+Size of this LU entry.  
   
- lu_type  
- The LU type (AP_LU0, AP_LU1, AP_LU2, or AP_LU3).  
+*access_type*  
+The access type (AP_3270 or AP_LUA).  
   
- lu_daf  
- The network addressable unit of the LU for which the information is displayed.  
+*lu_type*  
+The LU type (AP_LU0, AP_LU1, AP_LU2, or AP_LU3).  
   
- lu_short_name  
- The 1 byte ASCII LU short name.  
+*lu_daf*  
+The network addressable unit of the LU for which the information is displayed.  
   
- lu_long_name  
- The 8 byte ASCII LU long name.  
+*lu_short_name*  
+The 1 byte ASCII LU short name.  
   
- session_id  
- The LU-LU session ID.  
+*lu_long_name*  
+The 8 byte ASCII LU long name.  
   
- dlc_name  
- DLC name set to one of the following:  
+session_id  
+The LU-LU session ID.  
   
- IBMTRNET  
-  SDLC  
-  TWINAX (Not supported by Host Integration Server)  
-  X25DLC  
-  adapter_num  
- The DLC adapter number for host link. Always set to zero.  
+*dlc_name*  
+DLC name set to one of the following:  
   
- dest_addr_len  
- Length of the destination adapter address.  
+- IBMTRNET  
+- SDLC  
+- TWINAX (Not supported by Host Integration Server)  
+- X25DLC  
+
+*adapter_num*  
+The DLC adapter number for host link. Always set to zero.  
   
- dest_addr  
- The destination adapter address.  
+*dest_addr_len*  
+Length of the destination adapter address.  
   
- sscp_lu_sess_state  
- Specifies the state of the SSCP-LU session.  
+*dest_addr*  
+The destination adapter address.  
   
- lu_lu_sess_state  
- Specifies the state of the LU-LU session. The state can be one of the following:  
+*sscp_lu_sess_state*  
+Specifies the state of the SSCP-LU session.  
   
- AP_NOT_BOUND  
- The LU-LU session is not bound.  
+*lu_lu_sess_state*  
+Specifies the state of the LU-LU session. The state can be one of the following:  
   
- AP_BOUND  
- The LU-LU session is bound.  
+- AP_NOT_BOUND  
+  The LU-LU session is not bound.  
   
- AP_BINDING  
- The LU-LU session is in the process of binding.  
+- AP_BOUND  
+  The LU-LU session is bound.  
   
- AP_UNBINDING  
- The LU-LU session is in the process of unbinding.  
+- AP_BINDING  
+  The LU-LU session is in the process of binding.  
   
- link_id  
- Name of connection.
+- AP_UNBINDING  
+  The LU-LU session is in the process of unbinding.  
+  
+*link_id*  
+Name of connection.

--- a/his/core/lu-6-2-information1.md
+++ b/his/core/lu-6-2-information1.md
@@ -15,11 +15,12 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # LU 6.2 Information
+
 Information on LUs is provided in the **lu62_info_sect** structure as defined below.  
-  
+
 ## Syntax  
   
-```  
+``` 
 typedef struct lu62_info_sect {  
     unsigned long  lu62_init_sect_len;  
     unsigned short num_lu62s;  
@@ -27,19 +28,18 @@ typedef struct lu62_info_sect {
 } LU62_INFO_SECT;  
 ```  
   
-## Members  
- lu62_init_sect_len  
- Structure length.  
+## Members
+
+*lu62_init_sect_len*  
+Structure length.  
   
- num_lu62s  
- Number of configured LUs displayed.  
+*num_lu62s*  
+Number of configured LUs displayed.  
   
- total_lu62s  
- Total number of configured LUs.  
+*total_lu62s*  
+Total number of configured LUs.  
   
- For each configured LU, an **lu62_overlay** structure is provided as defined below.  
-  
-## Syntax  
+For each configured LU, an **lu62_overlay** structure is provided as defined below.  
   
 ```  
 typedef struct lu62_overlay {  
@@ -58,46 +58,45 @@ typedef struct lu62_overlay {
 } LU62_OVERLAY;  
 ```  
   
-## Members  
- lu62_entry_len  
- Size of this LU entry.  
+The **lu62_overlay** structure contains the following members:
   
- lu62_overlay_len  
- This value contains <strong>sizeof(</strong>struct **lu62_overlay)**–**sizeof(lu62_entry_len)**.  
+*lu62_entry_len*  
+Size of this LU entry.  
   
- lu_name  
- LU name (EBCDIC type A).  
+*lu62_overlay_len*  
+This value contains <strong>sizeof(</strong>struct **lu62_overlay)**–**sizeof(lu62_entry_len)**.  
   
- lu_alias  
- LU alias (ASCII).  
+*lu_name*  
+LU name (EBCDIC type A).  
   
- num_plus  
- Number of partner LUs.  
+*lu_alias*  
+LU alias (ASCII).  
   
- fqlu_name  
- Fully qualified LU name (EBCDIC type A).  
+*num_plus*  
+Number of partner LUs.  
+
+*fqlu_name*  
+Fully qualified LU name (EBCDIC type A).  
   
- default_lu  
- For local LU group, an LU equal to the **default_lu** is used if none is specified. Legal values are AP_NO and AP_YES.  
+*default_lu*  
+For local LU group, an LU equal to the **default_lu** is used if none is specified. Legal values are AP_NO and AP_YES.  
+
+On Host Integration Server, there is no concept of a default local LU. Therefore, the **default_lu** flag, which is set to AP_YES for the node in IBM ES for OS/2 version 1.0, is set to AP_NO for Host Integration Server.  
   
- On Host Integration Server, there is no concept of a default local LU. Therefore, the **default_lu** flag, which is set to AP_YES for the node in IBM ES for OS/2 version 1.0, is set to AP_NO for Host Integration Server.  
+*lu_local_addr*  
+NAU address, 0–254.  
   
- lu_local_addr  
- NAU address, 0–254.  
+*lu_sess_lim*  
+Configured session limit, 0–255.  
   
- lu_sess_lim  
- Configured session limit, 0–255.  
+*max_tps*  
+Maximum number of TPs, 1–255.  
   
- max_tps  
- Maximum number of TPs, 1–255.  
+*lu_type*  
+Always LU type 6.2.  
   
- lu_type  
- Always LU type 6.2.  
-  
- For each configured LU, a **plu_62_overlay** structure for the partner LU is provided as defined below.  
-  
-## Syntax  
-  
+For each configured LU, a **plu_62_overlay** structure for the partner LU is provided as defined below.  
+
 ```  
 typedef struct plu62_overlay {  
     unsigned long  plu62_entry_len;  
@@ -126,81 +125,83 @@ typedef struct plu62_overlay {
 } PLU62_OVERLAY;  
 ```  
   
-## Members  
- plu62_entry_len  
- Size of this partner LU entry.  
+The **plu_62_overlay** structure for the partner LU contains the following members:
   
- plu62_overlay_len  
- This value contains <strong>sizeof(</strong>struct **plu62_overlay)**–**sizeof(plu62_entry_len)**.  
+*plu62_entry_len*  
+Size of this partner LU entry.  
   
- plu_alias  
- Partner LU alias (ASCII).  
+*plu62_overlay_len*  
+This value contains <strong>sizeof(</strong>struct **plu62_overlay)**–**sizeof(plu62_entry_len)**.  
   
- num_modes  
- Number of modes.  
+*plu_alias*  
+Partner LU alias (ASCII).  
   
- plu_un_name  
- Partner LU uninterpreted name (EBCDIC).  
+*num_modes*  
+Number of modes.  
   
- fqplu_name  
- Fully qualified partner LU name (EBCDIC type A).  
+*plu_un_name*  
+Partner LU uninterpreted name (EBCDIC).  
   
- reserv3  
- Reserved field set to zero.  
+*fqplu_name*  
+Fully qualified partner LU name (EBCDIC type A).  
   
- plu_sess_lim  
- Partner LU session limit, 0–255.  
+*reserv3*  
+Reserved field set to zero.  
   
- dlc_name  
- DLC name (ASCII).  
+*plu_sess_lim*  
+Partner LU session limit, 0–255.  
   
- adapter_num  
- DLC adapter number.  
+*dlc_name*  
+DLC name (ASCII).  
   
- dest_addr_len  
- Length of destination adapter address.  
+*adapter_num*  
+DLC adapter number.  
   
- dest_addr  
- Destination adapter address.  
+*dest_addr_len*  
+Length of destination adapter address.  
   
- par_sess_supp  
- Bit 15 of a bitfield specifying parallel sessions. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
+*dest_addr*  
+Destination adapter address.  
   
- reserv4  
- Bits 8–14 of a bitfield specifying a reserved field set to zero.  
+*par_sess_supp*  
+Bit 15 of a bitfield specifying parallel sessions. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
   
- def_already_ver  
- Bit 7 of a bitfield specifying whether the configured already verified option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
+*reserv4*  
+Bits 8–14 of a bitfield specifying a reserved field set to zero.  
   
- def_conv_sec  
- Bit 6 of a bitfield specifying whether the configured conversation security option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
+*def_already_ver*  
+Bit 7 of a bitfield specifying whether the configured already verified option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
+
+*def_conv_sec*  
+Bit 6 of a bitfield specifying whether the configured conversation security option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
   
- def_sess_sec  
- Bit 5 of a bitfield specifying whether the configured session security option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
+*def_sess_sec*  
+Bit 5 of a bitfield specifying whether the configured session security option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
   
- reserv5  
- Bits 0–4 of a bitfield specifying a reserved field set to zero.  
+*reserv5*  
+Bits 0–4 of a bitfield specifying a reserved field set to zero.  
   
- act_already_ver  
- Bit 15 of a bitfield specifying whether the active already verified option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
+*act_already_ver*  
+Bit 15 of a bitfield specifying whether the active already verified option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
   
- act_conv_sec  
- Bit 14 of a bitfield specifying whether the active conversation security option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
+*act_conv_sec*  
+Bit 14 of a bitfield specifying whether the active conversation security option is supported. Valid values are AP_NOT_SUPPORTED and AP_SUPPORTED.  
   
- reserv6  
- Bits 8–13 of a bitfield specifying a reserved field set to zero.  
+*reserv6*  
+Bits 8–13 of a bitfield specifying a reserved field set to zero.  
   
- implicit_part  
- Bit 7 of a bitfield specifying whether this is an implicit partner. Valid values are AP_NO and AP_YES.  
+*implicit_part*  
+Bit 7 of a bitfield specifying whether this is an implicit partner. Valid values are AP_NO and AP_YES.  
   
- For partner LU group, **implicit_part** indicates the partner LU group was configured as an implicit primary logical unit (PLU).  
+For partner LU group, **implicit_part** indicates the partner LU group was configured as an implicit primary logical unit (PLU).  
   
- reserv7  
- Bits 0–6 of a bitfield specifying a reserved field set to zero.  
+*reserv7*  
+Bits 0–6 of a bitfield specifying a reserved field set to zero.  
   
-## Remarks  
- Host Integration Server returns information on all the configured LU 6.2s in the system, including the implicit PLU and all instances of implicit modes. IBM ES for OS/2 version 1.0 only returns information on those that are in use or have been in use.  
+## Remarks
   
- For partner LU group, **implicit_part** indicates the partner LU group was configured as an implicit primary logical unit (PLU).  
+Host Integration Server returns information on all the configured LU 6.2s in the system, including the implicit PLU and all instances of implicit modes. IBM ES for OS/2 version 1.0 only returns information on those that are in use or have been in use.  
   
- For mode group, **implicit_mode** bitfield returned in the **mode_overlay** structure indicates the mode group was configured as an implicit mode.
+For partner LU group, **implicit_part** indicates the partner LU group was configured as an implicit primary logical unit (PLU).  
+  
+For mode group, **implicit_mode** bitfield returned in the **mode_overlay** structure indicates the mode group was configured as an implicit mode.

--- a/his/core/management-services-information2.md
+++ b/his/core/management-services-information2.md
@@ -15,6 +15,7 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # Management Services Information
+
 Information on management services is provided in the **ms_info_sect** structure as defined below.  
   
 ## Syntax  
@@ -33,37 +34,36 @@ typedef struct ms_info_sect {
 } MS_INFO_SECT;  
 ```  
   
-## Members  
- ms_init_sect_len  
- The length of the initial MS information section, including this parameter, up to the first MS focal point group. The length does not include any previous information sections.  
+## Members
   
- held_mds_mu_alerts  
- The number of management service MDS alerts being held that will be sent to the management service alert focal point (FP) when one becomes available.  
+*ms_init_sect_len*  
+The length of the initial MS information section, including this parameter, up to the first MS focal point group. The length does not include any previous information sections.  
   
- held_nmvt_alerts  
- The number of management service NMVT alerts being held that will be sent to the management service alert focal point (FP) when one becomes available.  
+*held_mds_mu_alerts*  
+The number of management service MDS alerts being held that will be sent to the management service alert focal point (FP) when one becomes available.  
   
- num_fps  
- The number of management service focal points (MS FPs) for which the information listed under MS Focal Point Group is returned. This is the number of times the information group is repeated.  
+*held_nmvt_alerts*  
+The number of management service NMVT alerts being held that will be sent to the management service alert focal point (FP) when one becomes available.  
   
- total_fps  
- The total number of management service focal points for which APPC has information. This number is the same as the number returned in the **num_fps** member except when APPC has more information about management service focal points than it can place in the supplied buffer, in which case this number is larger.  
+*num_fps*  
+The number of management service focal points (MS FPs) for which the information listed under MS Focal Point Group is returned. This is the number of times the information group is repeated.  
   
- num_ms_appls  
- The number of registered MS applications for which the information listed under Registered MS Application Group is returned. This is the number of times the information group is repeated.  
+*total_fps*  
+The total number of management service focal points for which APPC has information. This number is the same as the number returned in the **num_fps** member except when APPC has more information about management service focal points than it can place in the supplied buffer, in which case this number is larger.  
   
- total_ms_appls  
- The total number of registered MS applications for which APPC has information. This number is the same as the number returned in the **num_ms_appls** member except when APPC has more information about registered MS applications than it can place in the supplied buffer, in which case this number is larger.  
+*num_ms_appls*  
+The number of registered MS applications for which the information listed under Registered MS Application Group is returned. This is the number of times the information group is repeated.  
   
- num_act_trans  
- The number of MS active transactions for which the information listed under MS Active Transaction Group is returned. This is the number of times the information group is repeated.  
+*total_ms_appls*  
+The total number of registered MS applications for which APPC has information. This number is the same as the number returned in the **num_ms_appls** member except when APPC has more information about registered MS applications than it can place in the supplied buffer, in which case this number is larger.  
   
- total_act_trans  
- The number or MS active transactions for which APPC has information. This number is the same as the number returned in the **num_act_trans** member except when APPC has more information about registered MS active transactions than it can place in the supplied buffer, in which case this number is larger.  
+*num_act_trans*  
+The number of MS active transactions for which the information listed under MS Active Transaction Group is returned. This is the number of times the information group is repeated.  
   
- For each local and remote management service focal point group, an **ms_fp_overlay** structure for the focal point group is provided as defined below.  
+*total_act_trans*  
+The number or MS active transactions for which APPC has information. This number is the same as the number returned in the **num_act_trans** member except when APPC has more information about registered MS active transactions than it can place in the supplied buffer, in which case this number is larger.  
   
-## Syntax  
+For each local and remote management service focal point group, an **ms_fp_overlay** structure for the focal point group is provided as defined below.  
   
 ```  
 typedef struct ms_fp_overlay {  
@@ -80,71 +80,73 @@ typedef struct ms_fp_overlay {
 } MS_FP_OVERLAY;  
 ```  
   
-## Members  
- ms_fp_entry_len  
- Size of this management service focal point information entry.  
+The **ms_fp_overlay** structure for the focal point group contains the following members:
   
- ms_appl_name  
- The management service application name of the current active focal point (EBCDIC).  
+*ms_fp_entry_len*  
+Size of this management service focal point information entry.  
   
- ms_category  
- The management service category.  
+*ms_appl_name*  
+The management service application name of the current active focal point (EBCDIC).  
   
- fp_fq_cp_name  
- The fully qualified control point name of the node on which the current (active) management service focal point is located (EBCDIC). If the local node has no focal point, a value of all EBCDIC space characters (0x40) is returned.  
+*ms_category*  
+The management service category.  
   
- bkup_appl_name  
- The management service application name of the backup focal point, if one is known (EBCDIC).  
+*fp_fq_cp_name*  
+The fully qualified control point name of the node on which the current (active) management service focal point is located (EBCDIC). If the local node has no focal point, a value of all EBCDIC space characters (0x40) is returned.  
   
- bkup_fp_fq_cp_name  
- The fully qualified control point name of the node on which the backup management service focal point is located, if one is known (EBCDIC). If the local node has no backup focal point, a value of all EBCDIC space characters (0x40) is returned.  
+*bkup_appl_name*  
+The management service application name of the backup focal point, if one is known (EBCDIC).  
   
- fp_type  
- The type of the focal point for the local management service entry point node. The focal point type depends on how the focal point-end point relationship was established, and on whether the local node is configured as an NN, EN, or LEN node (an EN without CP-CP session support). The type can be one of the following:  
+*bkup_fp_fq_cp_name*  
+The fully qualified control point name of the node on which the backup management service focal point is located, if one is known (EBCDIC). If the local node has no backup focal point, a value of all EBCDIC space characters (0x40) is returned.  
   
- AP_EXPLICIT_PRIMARY_FP  
- The current focal point type is explicit primary.  
+*fp_type*  
+The type of the focal point for the local management service entry point node. The focal point type depends on how the focal point-end point relationship was established, and on whether the local node is configured as an NN, EN, or LEN node (an EN without CP-CP session support). The type can be one of the following:  
   
- AP_BACKUP_FP  
- The current focal point type is back up.  
+- AP_EXPLICIT_PRIMARY_FP  
+  The current focal point type is explicit primary.  
   
- AP_DEFAULT_PRIMARY_FP  
- The current focal point type is default primary.  
+- AP_BACKUP_FP  
+  The current focal point type is back up.  
   
- AP_DOMAIN_FP  
- The current focal point type is domain.  
+- AP_DEFAULT_PRIMARY_FP  
+  The current focal point type is default primary.  
   
- AP_HOST_FP  
- The current focal point type is host.  
+- AP_DOMAIN_FP  
+  The current focal point type is domain.  
   
- AP_NO_FP  
- Currently the local node has no focal point.  
+- AP_HOST_FP  
+  The current focal point type is host.  
   
- fp_status  
- The status of the management service focal point. The status can be one of the following:  
+- AP_NO_FP  
+  Currently the local node has no focal point.  
   
- AP_NOT_ACTIVE  
- The focal point has been acquired, but has since become unavailable.  
+*fp_status*  
+The status of the management service focal point. The status can be one of the following:  
   
- AP_ACTIVE  
- The remote focal point has been acquired and is available.  
+- AP_NOT_ACTIVE  
+  The focal point has been acquired, but has since become unavailable.  
   
- AP_PENDING  
- A request has been sent to a remote primary or backup focal point to acquire that FP, and its reply has not yet been received.  
+- AP_ACTIVE  
+  The remote focal point has been acquired and is available.  
   
- AP_NEVER_ACTIVE  
- The focal point has never been acquired, but one or more registered management service applications have requested focal point information.  
+- AP_PENDING  
+  A request has been sent to a remote primary or backup focal point to acquire that FP, and its reply has not yet been received.  
   
- fp_routing  
- The routing used to send unsolicited requests to the management service focal point when the local node is an EN. Note that requests from an NN are always sent directly to the focal point.  
+- AP_NEVER_ACTIVE  
+  The focal point has never been acquired, but one or more registered management service applications have requested focal point information.  
   
- The routing can be one of the following:  
+*fp_routing*  
+The routing used to send unsolicited requests to the management service focal point when the local node is an EN. Note that requests from an NN are always sent directly to the focal point.  
+
+The routing can be one of the following:  
   
- AP_DEFAULT  
- Unsolicited management service requests destined for the focal point are sent from the EN to its serving NN for forwarding to the focal point.  
+- AP_DEFAULT  
+  Unsolicited management service requests destined for the focal point are sent from the EN to its serving NN for forwarding to the focal point.  
   
- AP_DIRECT  
- Unsolicited management service requests destined for the focal point are sent directly to the focal point.  
+- AP_DIRECT  
+  Unsolicited management service requests destined for the focal point are sent directly to the focal point.  
   
-## Remarks  
- When a program registers a management service application name, it can request focal point information. When APPC acquires the focal point, it passes the program the focal point information, which includes the type of routing to use to send unsolicited management service requests to the focal point.
+## Remarks
+  
+When a program registers a management service application name, it can request focal point information. When APPC acquires the focal point, it passes the program the focal point information, which includes the type of routing to use to send unsolicited management service requests to the focal point.

--- a/his/core/mode-definition-information1.md
+++ b/his/core/mode-definition-information1.md
@@ -15,16 +15,19 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # Mode Definition Information
+
 Mode definition information is defined or returned as described here.  
   
-## Defined by IBM ES for OS/2 version 1.0  
+## Defined by IBM ES for OS/2 version 1.0
+
+The following members are defined:
   
-## Members  
- cos_name  
- Name of class of service.  
+*cos_name*  
+Name of class of service.  
   
-## Returned by Host Integration Server  
+## Returned by Host Integration Server
+
+The following members are returned:
   
-## Members  
- cos_name  
- Set to EBCDIC spaces.
+*cos_name*  
+Set to EBCDIC spaces.

--- a/his/core/secondary-appc-return-codes2.md
+++ b/his/core/secondary-appc-return-codes2.md
@@ -34,7 +34,7 @@ The following table lists each return code by numeric value, along with the asso
 | 00000012          | AP_BAD_SYNC_LEVEL   | TThe value specified for **sync_level** was invalid. |
 | 00000013          | AP_BAD_SECURITY   | The value specified for **security** was invalid. |
 | 00000014          | AP_BAD_RETURN_CONTROL   | The value specified for **rtn_ctl** was invalid. |
-| 00000016          | AP_PIP_LEN_INCORRECT   | The value specified for **rtn_ctl** was invalid. |
+| 00000016          | AP_PIP_LEN_INCORRECT   | The value of **pip_dlen** was greater than 32767. |
 | 00000017          | AP_NO_USE_OF_SNASVCMG (for a mapped conversation)   | SNASVCMG is not a valid value for **mode_name**. |
 | 00000018          | AP_UNKNOWN_PARTNER_MODE   | The value specified for **mode_name** was invalid. |
 | 00000031          | AP_CONFIRM_ON_SYNC_LEVEL_NONE   | The local TP attempted to use [CONFIRM](../core/confirm2.md) or [MC_CONFIRM](../core/mc-confirm2.md) in a conversation with a synchronization level of AP_NONE. The synchronization level, established by [ALLOCATE](../core/allocate2.md) or [MC_ALLOCATE](../core/mc-allocate2.md), must be AP_CONFIRM_SYNC_LEVEL. |
@@ -52,6 +52,7 @@ The following table lists each return code by numeric value, along with the asso
 | 000000B1          | AP_RCV_AND_WAIT_BAD_STATE   | The conversation was not in RECEIVE or SEND state when the TP issued this verb. |
 | 000000B2          | AP_RCV_AND_WAIT_NOT_LL_BDY (for a basic conversation)   | The conversation was in SEND state; the TP began but did not finish sending a logical record. |
 | 000000B5          | AP_RCV_AND_WAIT_BAD_FILL (for a basic conversation)    | The **fill** parameter was set to an invalid value. |
+| 000000C1          | AP_RCV_IMMD_BAD_STATE    | The conversation was not in RECEIVE state. |
 | 000000D1          | AP_RCV_AND_POST_BAD_STATE   | The conversation was not in RECEIVE or SEND state when the TP issued this verb.  |
 | 000000D2          | AP_RCV_AND_POST_NOT_LL_BDY   | The conversation was in SEND state; the TP began but did not finish sending a logical record. |
 | 000000D5          | AP_RCV_AND_POST_BAD_FILL   | The **fill** parameter was set to an invalid value. |
@@ -72,6 +73,7 @@ The following table lists each return code by numeric value, along with the asso
 | 00000154          | AP_BAD_SNASVCMG_LIMITS | Your program specified invalid settings for the **partner_lu_mode_session_limit**, **min_conwinners_source**, or **min_conwinners_target** parameters when **mode_name** was supplied. |
 | 00000155          | AP_MIN_GT_TOTAL | The sum of **min_conwinners_source** and **min_conwinners_target** specifies a number greater than **partner_lu_mode_session_limit**. |
 | 00000156          | AP_MODE_CLOSED | The local LU cannot negotiate a nonzero session limit because the local maximum session limit at the partner LU is zero. |
+| 00000156          | AP_CNOS_MODE_CLOSED | The local LU cannot negotiate a nonzero session limit because the local maximum session limit at the partner LU is zero. |
 | 00000157          | AP_CNOS_MODE_NAME_REJECT | The partner LU does not recognize the specified mode name. |
 | 00000159          | AP_RESET_SNA_DRAINS | The SNASVCMG mode does not support the **drain** parameter values. |
 | 0000015A          | AP_SINGLE_NOT_SRC_RESP | For a single-session [CNOS](../core/cnos2.md) verb, APPC permits only the local (source) LU to be responsible for deactivating sessions. |

--- a/his/core/secondary-appc-return-codes2.md
+++ b/his/core/secondary-appc-return-codes2.md
@@ -15,333 +15,83 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # Secondary APPC Return Codes
-## 00000000  
- AP_CNOS_ACCEPTED  
- APPC accepts the session lines and responsibility as specified.  
-  
-## 00000001  
- AP_BAD_TP_ID  
- The value of **tp_id** did not match a transaction program (TP) identifier assigned by APPC.  
-  
-## 00000002  
- AP_BAD_CONV_ID  
- The value of **conv_id** did not match a conversation identifier assigned by APPC.  
-  
-## 00000003  
- AP_BAD_LU_ALIAS  
- APPC cannot find the specified **lu_alias** among those defined.  
-  
-## 000000C4  
- AP_RCV_IMMD_BAD_FILL (for a basic conversation)  
- The **fill** parameter was set to an invalid value.  
-  
-## 00000004  
- AP_ALLOCATION_FAILURE_NO_RETRY  
- The conversation cannot be allocated because of a permanent condition, such as a configuration error or session protocol error. To determine the error, the system administrator should examine the error log file. Do not retry the allocation until the error has been corrected.  
-  
-## 00000005  
- AP_ALLOCATION_FAILURE_RETRY  
- The conversation could not be allocated because of a temporary condition, such as a link failure. The reason for the failure is logged in the system error log. Retry the allocation.  
-  
-## 00000006  
- AP_INVALID_DATA_SEGMENT  
- The program initiation parameters (PIP) data was longer than the allocated data segment, or the address of the PIP data buffer was wrong.  
-  
-## 00000007  
- AP_CNOS_NEGOTIATED  
- APPC accepts the session limits and responsibility as negotiable by the partner logical unit (LU). Values that can be negotiated are:  
-  
- **plu_mode_session_limit**  
-  
- **min_conwinners_source**  
-  
- **min_conwinners_target**  
-  
- **responsible**  
-  
- **drain_target**  
-  
-## 000000D7  
- AP_BAD_RETURN_STATUS_WITH_DATA  
- The specified **rtn_status** value was not recognized by APPC.  
-  
-## 00000011  
- AP_BAD_CONV_TYPE (for a basic conversation)  
- The value specified for **conv_type** was invalid.  
-  
-## 00000012  
- AP_BAD_SYNC_LEVEL  
- The value specified for **sync_level** was invalid.  
-  
-## 00000013  
- AP_BAD_SECURITY  
- The value specified for **security** was invalid.  
-  
-## 00000014  
- AP_BAD_RETURN_CONTROL  
- The value specified for **rtn_ctl** was invalid.  
-  
-## 00000016  
- AP_PIP_LEN_INCORRECT  
- The value of **pip_dlen** was greater than 32767.  
-  
-## 00000017  
- AP_NO_USE_OF_SNASVCMG (for a mapped conversation)  
- SNASVCMG is not a valid value for **mode_name**.  
-  
-## 00000018  
- AP_UNKNOWN_PARTNER_MODE  
- The value specified for **mode_name** was invalid.  
-  
-## 00000031  
- AP_CONFIRM_ON_SYNC_LEVEL_NONE  
- The local TP attempted to use [CONFIRM](../core/confirm2.md) or [MC_CONFIRM](../core/mc-confirm2.md) in a conversation with a synchronization level of AP_NONE. The synchronization level, established by [ALLOCATE](../core/allocate2.md) or [MC_ALLOCATE](../core/mc-allocate2.md), must be AP_CONFIRM_SYNC_LEVEL.  
-  
-## 00000032  
- AP_CONFIRM_BAD_STATE  
- The conversation was not in SEND state.  
-  
-## 00000033  
- AP_CONFIRM_NOT_LL_BDY  
- The conversation for the local TP was in SEND state, and the local TP did not finish sending a logical record.  
-  
-## 00000051  
- AP_DEALLOC_BAD_TYPE  
- The **dealloc_type** parameter was not set to a valid value.  
-  
-## 00000052  
- AP_DEALLOC_FLUSH_BAD_STATE  
- The conversation was not in SEND state and the TP attempted to flush the send buffer. This attempt occurred because the value of **dealloc_type** was AP_FLUSH or because the value of **dealloc_type** was AP_SYNC_LEVEL and the synchronization level of the conversation was AP_NONE. In either case, the conversation must be in SEND state.  
-  
-## 00000053  
- AP_DEALLOC_CONFIRM_BAD_STATE  
- The conversation was not in SEND state, and the TP attempted to flush the send buffer and send a confirmation request.  
-  
-## 00000055  
- AP_DEALLOC_NOT_LL_BDY (for a basic conversation)  
- The conversation was in SEND state, and the TP did not finish sending a logical record. The **dealloc_type** parameter was set to AP_SYNC_LEVEL or AP_FLUSH.  
-  
-## 00000057  
- AP_DEALLOC_LOG_LL_WRONG  
- The LL field of the general data stream (GDS) error log variable did not match the actual length of the log data.  
-  
-## 00000061  
- AP_FLUSH_NOT_SEND_STATE  
- The conversation was not in SEND state.  
-  
-## 000000A1  
- AP_P_TO_R_INVALID_TYPE  
- The **ptr_type** parameter was not set to a valid value.  
-  
-## 000000A2  
- AP_P_TO_R_NOT_LL_BDY  
- The local TP did not finish sending a logical record.  
-  
-## 000000A3  
- AP_P_TO_R_NOT_SEND_STATE  
- The conversation was not in SEND state.  
-  
-## 000000B1  
- AP_RCV_AND_WAIT_BAD_STATE  
- The conversation was not in RECEIVE or SEND state when the TP issued this verb.  
-  
-## 000000B2  
- AP_RCV_AND_WAIT_NOT_LL_BDY (for a basic conversation)  
- The conversation was in SEND state; the TP began but did not finish sending a logical record.  
-  
-## 000000B5  
- AP_RCV_AND_WAIT_BAD_FILL (for a basic conversation)  
- The **fill** parameter was set to an invalid value.  
-  
-## 000000C1  
- AP_RCV_IMMD_BAD_STATE  
- The conversation was not in RECEIVE state.  
-  
-## 000000D1  
- AP_RCV_AND_POST_BAD_STATE  
- The conversation was not in RECEIVE or SEND state when the TP issued this verb.  
-  
-## 000000D2  
- AP_RCV_AND_POST_NOT_LL_BDY  
- The conversation was in SEND state; the TP began but did not finish sending a logical record.  
-  
-## 000000D5  
- AP_RCV_AND_POST_BAD_FILL  
- The **fill** parameter was set to an invalid value.  
-  
-## 000000D6  
- AP_INVALID_SEMAPHORE_HANDLE  
- The address of the RAM semaphore or system semaphore handle was invalid.  
-  
-> [!NOTE]
->  APPC cannot trap all invalid semaphore handles. If the TP passes a bad RAM semaphore handle, a protection violation results.  
-  
-## 000000D7  
- AP_BAD_RETURN_STATUS_WITH_DATA  
- The specified **rtn_status** value was not recognized by APPC.  
-  
-## 000000E1  
- AP_R_T_S_BAD_STATE  
- The conversation is not in an allowed state when the TP issued this verb.  
-  
-## 000000F1  
- AP_BAD_LL (for a basic conversation)  
- The logical record length field of a logical record contained an invalid value — 0x0000, 0x0001, 0x8000, or 0x8001. See [About Transaction Programs](./transaction-programs-overview1.md) for information on logical records.  
-  
-## 000000F2  
- AP_SEND_DATA_NOT_SEND_STATE  
- The local TP issued [SEND_DATA](../core/send-data1.md) or [MC_SEND_DATA](../core/mc-send-data1.md), but the conversation was not in SEND state.  
-  
-## 000000F5  
- AP_SEND_DATA_CONFIRM_ON_SYNC_NONE  
- The type CONFIRM is not permitted for a conversation that was allocated with a **sync_level** of NONE.  
-  
-## 000000F6  
- AP_SEND_DATA_NOT_LL_BDY (for a basic conversation)  
- The TP started but did not finish sending a logical record. This occurs only when **type** is one of the following:  
-  
- AP_SEND_DATA_CONFIRM  
-  
- AP_SEND_DATA_DEALLOC_FLUSH  
-  
- AP_SEND_DATA_DEALLOC_SYNC_LEVEL  
-  
- AP_SEND_DATA_P_TO_R_FLUSH  
-  
- AP_SEND_DATA_P_TO_R_SYNC_LEVEL  
-  
-## 00000102  
- AP_SEND_ERROR_LOG_LL_WRONG (for a basic conversation)  
- The LL field of the error log GDS variable did not match the actual length of the data.  
-  
-## 00000103  
- AP_SEND_ERROR_BAD_TYPE (for a basic conversation)  
- The value of **err_type** was invalid.  
-  
-## 00000105  
- AP_BAD_ERROR_DIRECTION  
- The specified **err_dir** was not recognized by APPC.  
-  
-## 00000150  
- AP_CNOS_IMPLICIT_PARALLEL  
- APPC does not permit a program to change the session limit for a mode other than SNASVCMG mode for the implicit partner template when the template specifies parallel sessions. (The term "template" is used because many of the actual values are yet to be filled in.)  
-  
-## 00000151  
- AP_CANT_RAISE_LIMITS  
- APPC does not permit setting session limits to a nonzero value unless the limits currently are zero.  
-  
-## 00000152  
- AP_AUTOACT_EXCEEDS_SESSLIM  
- On the [CNOS](../core/cnos2.md) verb, the value for **auto_activate** is greater than the value for **partner_lu_mode_session_limit**.  
-  
-## 00000153  
- AP_ALL_MODE_MUST_RESET  
- APPC does not permit a nonzero session limit when **mode_name_select** indicates ALL.  
-  
-## 00000154  
- AP_BAD_SNASVCMG_LIMITS  
- Your program specified invalid settings for the **partner_lu_mode_session_limit**, **min_conwinners_source**, or **min_conwinners_target** parameters when **mode_name** was supplied.  
-  
-## 00000155  
- AP_MIN_GT_TOTAL  
- The sum of **min_conwinners_source** and **min_conwinners_target** specifies a number greater than **partner_lu_mode_session_limit**.  
-  
-## 00000156  
- AP_MODE_CLOSED  
- The local LU cannot negotiate a nonzero session limit because the local maximum session limit at the partner LU is zero.  
-  
-## 00000156  
- AP_CNOS_MODE_CLOSED  
- The local LU cannot negotiate a nonzero session limit because the local maximum session limit at the partner LU is zero.  
-  
-## 00000157  
- AP_CNOS_MODE_NAME_REJECT  
- The partner LU does not recognize the specified mode name.  
-  
-## 00000159  
- AP_RESET_SNA_DRAINS  
- The SNASVCMG mode does not support the **drain** parameter values.  
-  
-## 0000015A  
- AP_SINGLE_NOT_SRC_RESP  
- For a single-session [CNOS](../core/cnos2.md) verb, APPC permits only the local (source) LU to be responsible for deactivating sessions.  
-  
-## 0000015B  
- AP_BAD_PARTNER_LU_ALIAS  
- APPC did not recognize the supplied **partner_lu_alias**.  
-  
-## 0000015C  
- AP_EXCEEDS_MAX_ALLOWED  
- Your program issued a [CNOS](../core/cnos2.md) verb, specifying a **partner_lu_mode_session_limit** number and **set_negotiable** (NO).  
-  
-## 0000015D  
- AP_CHANGE_SRC_DRAINS  
- APPC does not permit **mode_name_select** (ONE) and **drain_source** (YES) when **drain_source** (NO) is currently in effect for the specified mode.  
-  
-## 0000015E  
- AP_LU_DETACHED  
- A command reset the definition of the local LU before the [CNOS](../core/cnos2.md) verb tried to specify the LU.  
-  
-## 0000015F  
- AP_CNOS_COMMAND_RACE_REJECT  
- The local LU is currently processing a [CNOS](../core/cnos2.md) verb issued by the partner LU.  
-  
-## 00000167  
- AP_SNASVCMG_RESET_NOT_ALLOWED  
- Your local program attempted to issue the [CNOS](../core/cnos2.md) verbs for the mode named SNASVCMG, specifying a session limit of zero.  
-  
-## 000001B4  
- AP_DISPLAY_INFO_EXCEEDS_LENGTH  
- The returned [DISPLAY](../core/display2.md) information did not fit in the buffer.  
-  
-## 000001B5  
- DISPLAY_INVALID_CONSTANT  
- The value supplied for NUM_SECTIONS or INIT_SEC_LEN is invalid.  
-  
-## 00000506  
- AP_UNDEFINED_TP_NAME  
- In the configuration file for your application, APPC could not find an invokable TP name matching the value of **tp_name**.  
-  
-## 00000509  
- AP_ALLOCATE_NOT_PENDING  
- APPC did not find an incoming allocate (from the invoking TP) to match the value of **tp_name**, supplied by [RECEIVE_ALLOCATE](../core/receive-allocate1.md). **RECEIVE_ALLOCATE** waited for the incoming allocate and eventually timed out.  
-  
-## 00000519  
- AP_CPSVCMG_MODE_NOT_ALLOWED  
- The mode named CPSVCMG cannot be specified as the **mode_name** on the deactivate session verb.  
-  
-## 00000525  
- AP_INVALID_PROCESS  
- The process issuing [RECEIVE_ALLOCATE](../core/receive-allocate1.md) was different from the one started by APPC.  
-  
-## 080F6051  
- AP_SECURITY_NOT_VALID  
- The user identifier or password specified in the allocation request was not accepted by the partner LU.  
-  
-## 084B6031  
- AP_TRANS_PGM_NOT_AVAIL_RETRY  
- The remote LU rejected the allocation request because it was unable to start the requested partner TP. The condition may be temporary, such as a time-out. The reason for the error may be logged on the remote node. Retry the allocation.  
-  
-## 084C0000  
- AP_TRANS_PGM_NOT_AVAIL_NO_RETRY  
- The remote LU rejected the allocation request because it was unable to start the requested partner TP. The condition is permanent. The reason for the error may be logged on the remote node. Do not retry the allocation until the error has been corrected.  
-  
-## 10086021  
- AP_TP_NAME_NOT_RECOGNIZED  
- The partner LU does not recognize the TP name specified in the allocation request.  
-  
-## 10086031  
- AP_PIP_NOT_ALLOWED  
- The allocation request specified PIP data, but either the partner TP does not require this data, or the partner LU does not support it.  
-  
-## 10086032  
- AP_PIP_NOT_SPECIFIED_CORRECTLY  
- The partner TP requires PIP data, but the allocation request specified either no PIP data or an incorrect number of parameters.  
-  
-## 10086034  
- AP_CONVERSATION_TYPE_MISMATCH  
- The partner LU or TP does not support the conversation type (basic or mapped) specified in the allocation request.  
-  
-## 10086041  
- AP_SYNC_LEVEL_NOT_SUPPORTED  
- The partner TP does not support the **sync_level** (AP_NONE or AP_CONFIRM_SYNC_LEVEL) specified in the allocation request, or the **sync_level** was not recognized.
+
+The following table lists each return code by numeric value, along with the associated error message.
+
+| Return code value | Return code       | Error message                                                   |
+|-------------------|-------------------|-----------------------------------------------------------------|
+| 00000000          | AP_CNOS_ACCEPTED  | APPC accepts the session lines and responsibility as specified. |
+| 00000001          | AP_BAD_TP_ID      | The value of **tp_id** did not match a transaction program (TP) identifier assigned by APPC. |
+| 00000002          | AP_BAD_CONV_ID    | The value of **conv_id** did not match a conversation identifier assigned by APPC. |
+| 00000003          | AP_BAD_LU_ALIAS   | APPC cannot find the specified **lu_alias** among those defined. |
+| 000000C4          | AP_RCV_IMMD_BAD_FILL (for a basic conversation)  | The **fill** parameter was set to an invalid value. |
+| 00000004          | AP_ALLOCATION_FAILURE_NO_RETRY  | The conversation cannot be allocated because of a permanent condition, such as a configuration error or session protocol error. To determine the error, the system administrator should examine the error log file. Do not retry the allocation until the error has been corrected. |
+| 00000005          | AP_ALLOCATION_FAILURE_RETRY  | The conversation could not be allocated because of a temporary condition, such as a link failure. The reason for the failure is logged in the system error log. Retry the allocation. |
+| 00000006          | AP_INVALID_DATA_SEGMENT  | The program initiation parameters (PIP) data was longer than the allocated data segment, or the address of the PIP data buffer was wrong. |
+| 00000007          | AP_CNOS_NEGOTIATED  | APPC accepts the session limits and responsibility as negotiable by the partner logical unit (LU). Values that can be negotiated are:  **plu_mode_session_limit**, **min_conwinners_source**, **min_conwinners_target**, **responsible**, **drain_target** |
+| 000000D7          | AP_BAD_RETURN_STATUS_WITH_DATA   | The specified **rtn_status** value was not recognized by APPC. |
+| 00000011          | AP_BAD_CONV_TYPE (for a basic conversation) | The value specified for **conv_type** was invalid. |
+| 00000012          | AP_BAD_SYNC_LEVEL   | TThe value specified for **sync_level** was invalid. |
+| 00000013          | AP_BAD_SECURITY   | The value specified for **security** was invalid. |
+| 00000014          | AP_BAD_RETURN_CONTROL   | The value specified for **rtn_ctl** was invalid. |
+| 00000016          | AP_PIP_LEN_INCORRECT   | The value specified for **rtn_ctl** was invalid. |
+| 00000017          | AP_NO_USE_OF_SNASVCMG (for a mapped conversation)   | SNASVCMG is not a valid value for **mode_name**. |
+| 00000018          | AP_UNKNOWN_PARTNER_MODE   | The value specified for **mode_name** was invalid. |
+| 00000031          | AP_CONFIRM_ON_SYNC_LEVEL_NONE   | The local TP attempted to use [CONFIRM](../core/confirm2.md) or [MC_CONFIRM](../core/mc-confirm2.md) in a conversation with a synchronization level of AP_NONE. The synchronization level, established by [ALLOCATE](../core/allocate2.md) or [MC_ALLOCATE](../core/mc-allocate2.md), must be AP_CONFIRM_SYNC_LEVEL. |
+| 00000032          | AP_CONFIRM_BAD_STATE   | The conversation was not in SEND state. |
+| 00000033          | AP_CONFIRM_NOT_LL_BDY   | The conversation for the local TP was in SEND state, and the local TP did not finish sending a logical record. |
+| 00000051          | AP_DEALLOC_BAD_TYPE   | The **dealloc_type** parameter was not set to a valid value. |
+| 00000052          | AP_DEALLOC_FLUSH_BAD_STATE   | The conversation was not in SEND state and the TP attempted to flush the send buffer. This attempt occurred because the value of **dealloc_type** was AP_FLUSH or because the value of **dealloc_type** was AP_SYNC_LEVEL and the synchronization level of the conversation was AP_NONE. In either case, the conversation must be in SEND state. |
+| 00000053          | AP_DEALLOC_CONFIRM_BAD_STATE   | The conversation was not in SEND state, and the TP attempted to flush the send buffer and send a confirmation request.  |
+| 00000055          | AP_DEALLOC_NOT_LL_BDY (for a basic conversation)   | The conversation was in SEND state, and the TP did not finish sending a logical record. The **dealloc_type** parameter was set to AP_SYNC_LEVEL or AP_FLUSH. |
+| 00000057          | AP_DEALLOC_LOG_LL_WRONG   | The LL field of the general data stream (GDS) error log variable did not match the actual length of the log data. |
+| 00000061          | AP_FLUSH_NOT_SEND_STATE   | The conversation was not in SEND state. |
+| 000000A1          | AP_P_TO_R_INVALID_TYPE   | The **ptr_type** parameter was not set to a valid value. |
+| 000000A2          | AP_P_TO_R_NOT_LL_BDY   | The local TP did not finish sending a logical record. |
+| 000000A3          | AP_P_TO_R_NOT_SEND_STATE   | The conversation was not in SEND state. |
+| 000000B1          | AP_RCV_AND_WAIT_BAD_STATE   | The conversation was not in RECEIVE or SEND state when the TP issued this verb. |
+| 000000B2          | AP_RCV_AND_WAIT_NOT_LL_BDY (for a basic conversation)   | The conversation was in SEND state; the TP began but did not finish sending a logical record. |
+| 000000B5          | AP_RCV_AND_WAIT_BAD_FILL (for a basic conversation)    | The **fill** parameter was set to an invalid value. |
+| 000000D1          | AP_RCV_AND_POST_BAD_STATE   | The conversation was not in RECEIVE or SEND state when the TP issued this verb.  |
+| 000000D2          | AP_RCV_AND_POST_NOT_LL_BDY   | The conversation was in SEND state; the TP began but did not finish sending a logical record. |
+| 000000D5          | AP_RCV_AND_POST_BAD_FILL   | The **fill** parameter was set to an invalid value. |
+| 000000D6          | AP_INVALID_SEMAPHORE_HANDLE   | The address of the RAM semaphore or system semaphore handle was invalid. **NOTE**: APPC cannot trap all invalid semaphore handles. If the TP passes a bad RAM semaphore handle, a protection violation results. |
+| 000000D7          | AP_BAD_RETURN_STATUS_WITH_DATA   | The specified **rtn_status** value was not recognized by APPC. |
+| 000000E1          | AP_R_T_S_BAD_STATE   | The conversation is not in an allowed state when the TP issued this verb. |
+| 000000F1          | AP_BAD_LL (for a basic conversation)   | The logical record length field of a logical record contained an invalid value — 0x0000, 0x0001, 0x8000, or 0x8001. See [About Transaction Programs](./transaction-programs-overview1.md) for information on logical records. |
+| 000000F2          | AP_SEND_DATA_NOT_SEND_STATE   | The local TP issued [SEND_DATA](../core/send-data1.md) or [MC_SEND_DATA](../core/mc-send-data1.md), but the conversation was not in SEND state. |
+| 000000F5          | AP_SEND_DATA_CONFIRM_ON_SYNC_NONE   | The type CONFIRM is not permitted for a conversation that was allocated with a **sync_level** of NONE. |
+| 000000F6          | AP_SEND_DATA_NOT_LL_BDY (for a basic conversation)   | The TP started but did not finish sending a logical record. This occurs only when **type** is one of the following:  AP_SEND_DATA_CONFIRM, AP_SEND_DATA_DEALLOC_FLUSH, AP_SEND_DATA_DEALLOC_SYNC_LEVEL, AP_SEND_DATA_P_TO_R_FLUSH, AP_SEND_DATA_P_TO_R_SYNC_LEVEL |
+| 00000102          | AP_SEND_ERROR_LOG_LL_WRONG (for a basic conversation)   | The LL field of the error log GDS variable did not match the actual length of the data. |
+| 00000103          | AP_SEND_ERROR_BAD_TYPE (for a basic conversation) | The value of **err_type** was invalid. |
+| 00000105          | AP_BAD_ERROR_DIRECTION  | The specified **err_dir** was not recognized by APPC. |
+| 00000150          | AP_CNOS_IMPLICIT_PARALLEL |  APPC does not permit a program to change the session limit for a mode other than SNASVCMG mode for the implicit partner template when the template specifies parallel sessions. (The term "template" is used because many of the actual values are yet to be filled in.) |
+| 00000151          | AP_CANT_RAISE_LIMITS | APPC does not permit setting session limits to a nonzero value unless the limits currently are zero. |
+| 00000152          | AP_AUTOACT_EXCEEDS_SESSLIM | On the [CNOS](../core/cnos2.md) verb, the value for **auto_activate** is greater than the value for **partner_lu_mode_session_limit**. |
+| 00000153          | AP_ALL_MODE_MUST_RESET | APPC does not permit a nonzero session limit when **mode_name_select** indicates ALL. |
+| 00000154          | AP_BAD_SNASVCMG_LIMITS | Your program specified invalid settings for the **partner_lu_mode_session_limit**, **min_conwinners_source**, or **min_conwinners_target** parameters when **mode_name** was supplied. |
+| 00000155          | AP_MIN_GT_TOTAL | The sum of **min_conwinners_source** and **min_conwinners_target** specifies a number greater than **partner_lu_mode_session_limit**. |
+| 00000156          | AP_MODE_CLOSED | The local LU cannot negotiate a nonzero session limit because the local maximum session limit at the partner LU is zero. |
+| 00000157          | AP_CNOS_MODE_NAME_REJECT | The partner LU does not recognize the specified mode name. |
+| 00000159          | AP_RESET_SNA_DRAINS | The SNASVCMG mode does not support the **drain** parameter values. |
+| 0000015A          | AP_SINGLE_NOT_SRC_RESP | For a single-session [CNOS](../core/cnos2.md) verb, APPC permits only the local (source) LU to be responsible for deactivating sessions. |
+| 0000015B          | AP_BAD_PARTNER_LU_ALIAS | APPC did not recognize the supplied **partner_lu_alias**. |
+| 0000015C          | AP_EXCEEDS_MAX_ALLOWED | Your program issued a [CNOS](../core/cnos2.md) verb, specifying a **partner_lu_mode_session_limit** number and **set_negotiable** (NO). |
+| 0000015D          | AP_CHANGE_SRC_DRAINS | APPC does not permit **mode_name_select** (ONE) and **drain_source** (YES) when **drain_source** (NO) is currently in effect for the specified mode. |
+| 0000015E          | AP_LU_DETACHED |  A command reset the definition of the local LU before the [CNOS](../core/cnos2.md) verb tried to specify the LU. |
+| 0000015F          | AP_CNOS_COMMAND_RACE_REJECT | The local LU is currently processing a [CNOS](../core/cnos2.md) verb issued by the partner LU. |
+| 00000167          | AP_SNASVCMG_RESET_NOT_ALLOWED  | Your local program attempted to issue the [CNOS](../core/cnos2.md) verbs for the mode named SNASVCMG, specifying a session limit of zero. |
+| 000001B4          | AP_DISPLAY_INFO_EXCEEDS_LENGTH  | The returned [DISPLAY](../core/display2.md) information did not fit in the buffer. |
+| 000001B5          | DISPLAY_INVALID_CONSTANT  | The value supplied for NUM_SECTIONS or INIT_SEC_LEN is invalid. |
+| 00000506          | AP_UNDEFINED_TP_NAME  | In the configuration file for your application, APPC could not find an invokable TP name matching the value of **tp_name**. |
+| 00000509          | AP_ALLOCATE_NOT_PENDING  | APPC did not find an incoming allocate (from the invoking TP) to match the value of **tp_name**, supplied by [RECEIVE_ALLOCATE](../core/receive-allocate1.md). **RECEIVE_ALLOCATE** waited for the incoming allocate and eventually timed out. |
+| 00000519          | AP_CPSVCMG_MODE_NOT_ALLOWED  | The mode named CPSVCMG cannot be specified as the **mode_name** on the deactivate session verb. |
+| 00000525          | AP_INVALID_PROCESS  | The process issuing [RECEIVE_ALLOCATE](../core/receive-allocate1.md) was different from the one started by APPC.  |
+| 080F6051          | AP_SECURITY_NOT_VALID  | The user identifier or password specified in the allocation request was not accepted by the partner LU. |
+| 084B6031          | AP_TRANS_PGM_NOT_AVAIL_RETRY | The remote LU rejected the allocation request because it was unable to start the requested partner TP. The condition may be temporary, such as a time-out. The reason for the error may be logged on the remote node. Retry the allocation. |
+| 084C0000          | AP_TRANS_PGM_NOT_AVAIL_NO_RETRY  | The remote LU rejected the allocation request because it was unable to start the requested partner TP. The condition is permanent. The reason for the error may be logged on the remote node. Do not retry the allocation until the error has been corrected. |
+| 10086021          | AP_TP_NAME_NOT_RECOGNIZED  | The partner LU does not recognize the TP name specified in the allocation request. |
+| 10086031          | AP_PIP_NOT_ALLOWED  | The allocation request specified PIP data, but either the partner TP does not require this data, or the partner LU does not support it. |
+| 10086032          | AP_PIP_NOT_SPECIFIED_CORRECTLY  | The partner TP requires PIP data, but the allocation request specified either no PIP data or an incorrect number of parameters.  |
+| 10086034          | AP_CONVERSATION_TYPE_MISMATCH  | The partner LU or TP does not support the conversation type (basic or mapped) specified in the allocation request.   |
+| 10086041          | AP_SYNC_LEVEL_NOT_SUPPORTED  | The partner TP does not support the **sync_level** (AP_NONE or AP_CONFIRM_SYNC_LEVEL) specified in the allocation request, or the **sync_level** was not recognized. |

--- a/his/core/session-information1.md
+++ b/his/core/session-information1.md
@@ -15,6 +15,7 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # Session Information
+
 Information on session information is provided in the **sess_info_sect** structure as defined below.  
   
 ## Syntax  
@@ -27,19 +28,18 @@ typedef struct sess_info_sect {
 } SESS_INFO_SECT;  
 ```  
   
-## Members  
- sess_sect_len  
- The length of the initial session information section, including this parameter, up to the first session group. The length does not include any previous information sections.  
+## Members
   
- num_sessions  
- The number of session groups returned by the **DISPLAY** verb into your program's buffer. This is the number of times the session group is repeated.  
+*sess_sect_len*  
+The length of the initial session information section, including this parameter, up to the first session group. The length does not include any previous information sections.  
   
- total_sessions  
- The total number of session groups. This number is the same as the number returned in the **num_sessions** member except when APPC has more information about session groups than it can place in the supplied buffer, in which case this number is larger.  
+*num_sessions*  
+The number of session groups returned by the **DISPLAY** verb into your program's buffer. This is the number of times the session group is repeated.  
   
- For each session group, a **sess_overlay** structure for the session is provided as defined below.  
+*total_sessions*  
+The total number of session groups. This number is the same as the number returned in the **num_sessions** member except when APPC has more information about session groups than it can place in the supplied buffer, in which case this number is larger.  
   
-## Syntax  
+For each session group, a **sess_overlay** structure for the session is provided as defined below.  
   
 ```  
 typedef struct sess_overlay {  
@@ -71,175 +71,174 @@ typedef struct sess_overlay {
 ```  
   
 ## Defined by IBM ES for OS/2 version 1.0  
+
+The **sess_overlay** structure as defined by IBM ES for OS/2 version 1.0 contains the following members:
   
-## Members  
- sess_entry_len  
- Size of this session group entry.  
+*sess_entry_len*  
+Size of this session group entry.  
   
- sess_id  
- The internal identifier of the session for which this information is displayed.  
+*sess_id*  
+The internal identifier of the session for which this information is displayed.  
   
- conv_id  
- The unique four-byte ID of the conversation currently using this session.  
+*conv_id*  
+The unique four-byte ID of the conversation currently using this session.  
   
- lu_alias  
- LU alias (ASCII).  
+*lu_alias*  
+LU alias (ASCII).  
   
- plu_alias  
- Partner LU alias (ASCII).  
+*plu_alias*  
+Partner LU alias (ASCII).  
   
- mode_name  
- The name of the mode (EBCDIC).  
+*mode_name*  
+The name of the mode (EBCDIC).  
   
- send_ru_size  
- The maximum RU size used on this session and this **mode_name** for sending RUs.  
+*send_ru_size* 
+The maximum RU size used on this session and this **mode_name** for sending RUs.  
   
- rcv_ru_size  
- The maximum RU size used on this session and this **mode_name** for receiving RUs.  
+*rcv_ru_size*  
+The maximum RU size used on this session and this **mode_name** for receiving RUs.  
   
- send_pacing_size  
- The size of the send pacing window on this session.  
+*send_pacing_size*  
+The size of the send pacing window on this session.  
   
- rcv_pacing_size  
- The size of the receive pacing window on this session.  
+*rcv_pacing_size*  
+The size of the receive pacing window on this session.  
   
- link_id  
- Name of local logical link station.  
+*link_id*  
+Name of local logical link station.  
   
- daf  
- The destination address field for this session.  
+*daf*  
+The destination address field for this session.  
   
- oaf  
- The origin address field for this session.  
+*oaf*  
+The origin address field for this session.  
   
- odai  
- The origin destination address indicator field for this session.  
+*odai*  
+The origin destination address indicator field for this session.  
   
- sess_type  
- The type of the session. The session type can be one of the following:  
+*sess_type*  
+The type of the session. The session type can be one of the following:  
   
- SSCP_PU_SESSION  
- This session is between a workstation physical unit and a host system services control point. This type of session exists if the local node contains a dependent LU, or if the session has been solicited in order to send alerts to the host.  
+- SSCP_PU_SESSION  
+  This session is between a workstation physical unit and a host system services control point. This type of session exists if the local node contains a dependent LU, or if the session has been solicited in order to send alerts to the host.  
   
- SSCP_LU_SESSION  
- This session is between a dependent LU and a host system services control point.  
+- SSCP_LU_SESSION  
+  This session is between a dependent LU and a host system services control point.  
   
- LU_LU _SESSION  
- This session is between two LUs.  
+- LU_LU _SESSION  
+  This session is between two LUs.  
   
- conn_type  
- Indicates whether the session activation protocol follows the rules for an independent LU or a dependent LU. The connection type can be one of the following:  
+*conn_type*  
+Indicates whether the session activation protocol follows the rules for an independent LU or a dependent LU. The connection type can be one of the following:  
   
- AP_HOST_SESSION  
- For dependent LU protocols, the workstation LU is defined as dependent at the host, the host LU sends the session activation request (BIND), and each workstation LU can support only one session at a time.  
+- AP_HOST_SESSION  
+  For dependent LU protocols, the workstation LU is defined as dependent at the host, the host LU sends the session activation request (BIND), and each workstation LU can support only one session at a time.  
   
- AP_PEER_SESSION  
- For independent LU protocols, an LU can send a BIND, and can have multiple sessions to different partners, or parallel sessions to the same partner LU.  
+- AP_PEER_SESSION  
+  For independent LU protocols, an LU can send a BIND, and can have multiple sessions to different partners, or parallel sessions to the same partner LU.  
   
- fq_pc_id  
- Fully qualified procedure correlation identifier of the session.  
+*fq_pc_id*  
+Fully qualified procedure correlation identifier of the session.  
   
- cgid  
- Unique identifier for the conversation group of the session.  
+*cgid*  
+Unique identifier for the conversation group of the session.  
   
- fqlu_name  
- The fully-qualified LU name in EBCDIC (type A).  
+*fqlu_name*  
+The fully-qualified LU name in EBCDIC (type A).  
   
- fqplu_name  
- The fully-qualified partner LU name in EBCDIC (type A).  
+*fqplu_name*  
+The fully-qualified partner LU name in EBCDIC (type A).  
   
- pacing_type  
- The pacing type can be one of the following:  
+*pacing_type*  
+The pacing type can be one of the following:  
   
- AP_FIXED  
- Fixed pacing.  
+- AP_FIXED  
+  Fixed pacing.  
   
- AP_ADAPTIVE  
- Adaptive pacing.  
+- AP_ADAPTIVE  
+  Adaptive pacing.  
   
 ## Returned by Host Integration Server  
   
-## Members  
- sess_entry_len  
- Size of this session group entry.  
+The **sess_overlay** structure returned by Host Integration Server contains the following members:
   
- sess_id  
- The internal identifier of the session for which this information is displayed.  
+*sess_entry_len*  
+Size of this session group entry.  
   
- conv_id  
- The unique four-byte ID of the conversation currently using this session.  
+*sess_id*  
+The internal identifier of the session for which this information is displayed.  
   
- lu_alias  
- LU alias (ASCII).  
+*conv_id*  
+The unique four-byte ID of the conversation currently using this session.  
   
- plu_alias  
- Partner LU alias (ASCII).  
+*lu_alias*  
+LU alias (ASCII).  
   
- mode_name  
- The name of the mode (EBCDIC).  
+*plu_alias*  
+Partner LU alias (ASCII).  
   
- mode_name  
- The name of the mode (EBCDIC).  
+*mode_name*  
+The name of the mode (EBCDIC).  
+
+*send_ru_size*  
+The maximum RU size used on this session and this **mode_name** for sending RUs.  
   
- send_ru_size  
- The maximum RU size used on this session and this **mode_name** for sending RUs.  
+*rcv_ru_size*  
+The maximum RU size used on this session and this **mode_name** for receiving RUs.  
   
- rcv_ru_size  
- The maximum RU size used on this session and this **mode_name** for receiving RUs.  
+*send_pacing_size*  
+The size of the send pacing window on this session.  
   
- send_pacing_size  
- The size of the send pacing window on this session.  
+*rcv_pacing_size*  
+The size of the receive pacing window on this session.  
   
- rcv_pacing_size  
- The size of the receive pacing window on this session.  
+*link_id*  
+Connection name.  
   
- link_id  
- Connection name.  
+*daf*  
+The destination address field for this session.  
   
- daf  
- The destination address field for this session.  
+*oaf*  
+The origin address field for this session.  
   
- oaf  
- The origin address field for this session.  
+*odai*  
+The origin destination address indicator field for this session.  
   
- odai  
- The origin destination address indicator field for this session.  
+*sess_type*  
+The type of the session. The session type can be one of the following:  
   
- sess_type  
- The type of the session. The session type can be one of the following:  
+- SSCP_PU_SESSION  
+  This session is between a workstation physical unit and a host system services control point. This value is never returned by Host Integration Server.  
   
- SSCP_PU_SESSION  
- This session is between a workstation physical unit and a host system services control point. This value is never returned by Host Integration Server.  
+- SSCP_LU_SESSION  
+  This session is between a dependent LU and a host system services control point.  
+
+- LU_LU _SESSION  
+  This session is between two LUs.  
   
- SSCP_LU_SESSION  
- This session is between a dependent LU and a host system services control point.  
+*conn_type*  
+Indicates whether the session activation protocol follows the rules for an independent LU or a dependent LU. The connection type can be one of the following:  
   
- LU_LU _SESSION  
- This session is between two LUs.  
+- AP_HOST_SESSION  
+  For dependent LU protocols, the workstation LU is defined as dependent at the host, the host LU sends the session activation request (BIND), and each workstation LU can support only one session at a time.  
   
- conn_type  
- Indicates whether the session activation protocol follows the rules for an independent LU or a dependent LU. The connection type can be one of the following:  
+- AP_PEER_SESSION  
+  For independent LU protocols, an LU can send a BIND, and can have multiple sessions to different partners, or parallel sessions to the same partner LU.  
   
- AP_HOST_SESSION  
- For dependent LU protocols, the workstation LU is defined as dependent at the host, the host LU sends the session activation request (BIND), and each workstation LU can support only one session at a time.  
+- AP_BOTH_SESSION  
+  Connections can support both Dependent and Independent LUs.  
   
- AP_PEER_SESSION  
- For independent LU protocols, an LU can send a BIND, and can have multiple sessions to different partners, or parallel sessions to the same partner LU.  
+*fq_pc_id*  
+Set to zero.  
   
- AP_BOTH_SESSION  
- Connections can support both Dependent and Independent LUs.  
+*cgid*  
+Set to zero.  
   
- fq_pc_id  
- Set to zero.  
+*type_of_pacing*  
+The pacing type can be one of the following:  
   
- cgid  
- Set to zero.  
+- AP_FIXED  
+  Fixed pacing.  
   
- type_of_pacing  
- The pacing type can be one of the following:  
-  
- AP_FIXED  
- Fixed pacing.  
-  
- AP_ADAPTIVE  
- Adaptive pacing. This value is never returned by Host Integration Server.
+- AP_ADAPTIVE  
+  Adaptive pacing. This value is never returned by Host Integration Server.

--- a/his/core/sna-global-information2.md
+++ b/his/core/sna-global-information2.md
@@ -15,10 +15,12 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # SNA Global Information
+
 SNA global information is defined or returned as described here.  
   
-## Defined by IBM ES for OS/2 version 1.0  
- Information on SNA global information is provided in the **sna_global_info_sect** structure as defined below.  
+## Defined by IBM ES for OS/2 version 1.0
+  
+Information on SNA global information is provided in the **sna_global_info_sect** structure as defined below.  
   
 ```  
 typedef struct sna_global_info_sect {  
@@ -39,51 +41,53 @@ typedef struct sna_global_info_sect {
 } SNA_GLOBAL_INFO_SECT;  
 ```  
   
-## Members  
- version  
- Communications Manager Extended Edition version number.  
+The **sna_global_info_sect** structure as defined by IBM ES for OS/2 version 1.0 contains the following members:
   
- release  
- Communications Manager Extended Edition release number.  
+*version*  
+Communications Manager Extended Edition version number.  
   
- net_name  
- Network name, first part of fully qualified control program (CP) name, in EBCDIC (type A).  
+*release*  
+Communications Manager Extended Edition release number.  
   
- pu_name  
- PU name, second part of fully qualified CP name, in EBCDIC (type A).  
+*net_name*  
+Network name, first part of fully qualified control program (CP) name, in EBCDIC (type A).  
   
- node_id  
- 4-byte hexadecimal exchange identifier.  
+*pu_name*  
+PU name, second part of fully qualified CP name, in EBCDIC (type A).  
   
- product_set_id  
- Computer product data.  
+*node_id*  
+4-byte hexadecimal exchange identifier.  
   
- alias_cp_name  
- Node name (local name for CP) in ASCII.  
+*product_set_id*  
+Computer product data.  
   
- node_type  
- AP_NN, AP_EN, or AP_LEN.  
+*alias_cp_name*  
+Node name (local name for CP) in ASCII.  
   
- cp_nau_addr  
- CP NAU address where 0 means not used (an independent LU). Other legal values are 1 to 254.  
+*node_type*  
+AP_NN, AP_EN, or AP_LEN.  
   
- corr_serv_disk  
- Last four digits of corrective service disk number.  
+*cp_nau_addr*  
+CP NAU address where 0 means not used (an independent LU). Other legal values are 1 to 254.  
   
- reserved  
- Reserved field.  
+*corr_serv_disk*  
+Last four digits of corrective service disk number.  
   
- appc_version  
- APPC version number.  
+*reserved*  
+Reserved field.  
   
- appc_release  
- APPC release number.  
+*appc_version*  
+APPC version number.  
   
- appc_fixlevel  
- APPC patch number.  
+*appc_release*  
+APPC release number.  
   
-## Returned by Host Integration Server  
- Information on SNA global information is provided in the **sna_global_info_sect** structure defined below.  
+*appc_fixlevel*  
+APPC patch number.  
+  
+## Returned by Host Integration Server
+  
+Information on SNA global information is provided in the **sna_global_info_sect** structure defined below.  
   
 ```  
 typedef struct sna_global_info_sect {  
@@ -104,50 +108,52 @@ typedef struct sna_global_info_sect {
 } SNA_GLOBAL_INFO_SECT;  
 ```  
   
-## Members  
- version  
- Major operating system version number.  
+The **sna_global_info_sect** structure returned by Host Integration Server contains the following members:
   
- release  
- Minor operating system version number.  
+*version*  
+Major operating system version number.  
   
- net_name  
- Node network name in EBCDIC (type A).  
+*release* 
+Minor operating system version number.  
   
- pu_name  
- PU name in EBCDIC (type A) associated with connection.  
+*net_name*  
+Node network name in EBCDIC (type A).  
   
- node_id  
- Node identifier to send.  
+*pu_name*  
+PU name in EBCDIC (type A) associated with connection.  
   
- product_set_id  
- Set to EBCDIC zeros.  
+*node_id*  
+Node identifier to send.  
   
- alias_cp_name  
- Node name, local name for the control program (CP), in ASCII.  
+*product_set_id*  
+Set to EBCDIC zeros.  
   
- node_type  
- Set to AP_LEN.  
+*alias_cp_name*  
+Node name, local name for the control program (CP), in ASCII.  
   
- cp_nau_addr  
- CP NAU address where 0 means not used (an independent LU). Other legal values are 1 to 254.  
+*node_type*  
+Set to AP_LEN.  
   
- corr_serv_disk  
- Reserved field set to zero.  
+*cp_nau_addr*  
+CP NAU address where 0 means not used (an independent LU). Other legal values are 1 to 254.  
   
- reserved  
- Reserved field set to zero.  
+*corr_serv_disk*  
+Reserved field set to zero.  
   
- appc_version  
- Host Integration Server major version number.  
+*reserved*  
+Reserved field set to zero.  
   
- appc_release  
- Host Integration Server minor version number.  
+*appc_version*  
+Host Integration Server major version number.  
   
- appc_fixlevel  
- Host Integration Server patch number.  
+*appc_release*  
+Host Integration Server minor version number.  
   
-## Remarks  
- Host Integration Server returns **version** and **release** as the major and minor operating system version numbers from **GetVersion**. Because Host Integration Server has no information on the computer type, serial number, and manufacturer, **product_set_id** is set to EBCDIC zeros.  
+*appc_fixlevel*  
+Host Integration Server patch number.  
   
- Host Integration Server does not support APPN node types, so the node type is returned as 1 (an AP_LEN node), and not 2 or 3 (AP_NN or AP_EN nodes), as defined by IBM ES for OS/2 version 1.0.
+## Remarks
+  
+Host Integration Server returns **version** and **release** as the major and minor operating system version numbers from **GetVersion**. Because Host Integration Server has no information on the computer type, serial number, and manufacturer, **product_set_id** is set to EBCDIC zeros.  
+  
+Host Integration Server does not support APPN node types, so the node type is returned as 1 (an AP_LEN node), and not 2 or 3 (AP_NN or AP_EN nodes), as defined by IBM ES for OS/2 version 1.0.

--- a/his/core/system-default-information1.md
+++ b/his/core/system-default-information1.md
@@ -15,73 +15,77 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # System Default Information
+
 System default information is defined or returned as described here.  
   
 ## Defined by IBM ES for OS/2 version 1.0  
   
-## Members  
- default_mode_name  
- Mode name used for undefined mode name is sent or received.  
+The system default information defined by IBM ES for OS/2 version 1.0 contains the following members:
   
- default_local_lu_name  
- Alias or local default LU.  
+*default_mode_name*  
+Mode name used for undefined mode name is sent or received.  
   
- implicit_partner_lu_support  
- Indicates if implicit partner LU support is enabled.  
+*default_local_lu_name*  
+Alias or local default LU.  
   
- maximum_held_alerts  
- Number of alerts that will be held by NS/2 if there is no active link to a focal point.  
+*implicit_partner_lu_support* 
+Indicates if implicit partner LU support is enabled.  
   
- default_tp_conversation_security_rqd  
- Specifies if conversation security is used for default TPs.  
+*maximum_held_alerts*  
+Number of alerts that will be held by NS/2 if there is no active link to a focal point.  
   
- maximum_mc_ll_send_size  
- Maximum length of a logical record used on a mapped conversation for sending data to either the inbound or outbound implicit remote LU.  
+*default_tp_conversation_security_rqd* 
+Specifies if conversation security is used for default TPs.  
   
- directory_for_inbound_attaches  
- Name of OS/2 directory used by Attach Manager.  
+*maximum_mc_ll_send_size*  
+Maximum length of a logical record used on a mapped conversation for sending data to either the inbound or outbound implicit remote LU.  
   
- default_tp_operation  
- Set to one of the following:  
+*directory_for_inbound_attaches*  
+Name of OS/2 directory used by Attach Manager.  
   
- QUEUED_OPERATOR_STARTED  
-  QUEUED_OPERATOR_PRELOADED  
-  QUEUED_AM_STARTED  
-  NONQUEUED_AM_STARTED  
-  default_tp_program_type  
- Set to one of the following:  
+*default_tp_operation*  
+Set to one of the following:  
   
- BACKGROUND  
-  FULL_SCREEN  
-  PRESENTATION_MANAGER  
-  VIO_WINDOWABLE  
+- QUEUED_OPERATOR_STARTED  
+- QUEUED_OPERATOR_PRELOADED  
+- QUEUED_AM_STARTED  
+- NONQUEUED_AM_STARTED  
+
+*default_tp_program_type*  
+Set to one of the following:  
+  
+- BACKGROUND  
+- FULL_SCREEN  
+- PRESENTATION_MANAGER  
+- VIO_WINDOWABLE  
   
 ## Returned by Host Integration Server  
   
-## Members  
- default_mode_name  
- Always set to NULL.  
+The system default information returned by Host Integration Server contains the following members:
   
- default_local_lu_name  
- Always set to spaces.  
+*default_mode_name*  
+Always set to NULL.  
   
- implicit_partner_lu_support  
- Always set to NO.  
+*default_local_lu_name*  
+Always set to spaces.  
   
- maximum_held_alerts  
- Always set to zero.  
+*implicit_partner_lu_support*  
+Always set to NO.  
   
- default_tp_conversation_security_rqd  
- Always set to NO.  
+*maximum_held_alerts*  
+Always set to zero.  
   
- maximum_mc_ll_send_size  
- Always set to 16384.  
+*default_tp_conversation_security_rqd*  
+Always set to NO.  
   
- directory_for_inbound_attaches  
- Always returned * and indicates that the current path should be used.  
+*maximum_mc_ll_send_size*  
+Always set to 16384.  
   
- default_tp_operation  
- Always set to QUEUED_AM_STARTED.  
+*directory_for_inbound_attaches*  
+Always returned * and indicates that the current path should be used.  
   
- default_tp_program_type  
- Always set to FULL_SCREEN.
+*default_tp_operation*  
+Always set to QUEUED_AM_STARTED.  
+  
+*default_tp_program_type*  
+Always set to FULL_SCREEN.

--- a/his/core/tecwrksd1.md
+++ b/his/core/tecwrksd1.md
@@ -15,6 +15,7 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # tecwrksd
+
 Tecwrksd is a logical unit (LU)/session information record, which includes details of a 3270 LU.  
   
 ## Syntax  
@@ -29,28 +30,29 @@ typedef struct tecwrksd {
 } TECWRKSD;  
 ```  
   
-## Members  
- *cwshost[9]*  
- LU/pool name accessed.  
+## Members
+
+*cwshost[9]*  
+LU/pool name accessed.  
   
- *cwsestyp*  
- Session type (M2, M3, M4, M5, printer).  
+*cwsestyp*  
+Session type (M2, M3, M4, M5, printer).  
   
- *cwsmodov*  
- Whether the user has override permission.  
+*cwsmodov*  
+Whether the user has override permission.  
   
- *cwspad*  
- Two bytes of padding.  
+*cwspad*  
+Two bytes of padding.  
   
-## Remarks  
- The following "Members" list explains the meaning of each field in the structures and indicates how the application should use each field. For more information about Host Integration Server 3270 configuration, see [Configuration Information](../core/configuration-information1.md).  
+## Remarks
   
-## Members  
- *cwshost*  
- The name (up to eight characters) of the LU or LU pool that this session is configured to use. The application specifies this name on the [Open(SSCP) Request](./open-sscp-request2.md).  
+The following list of members explains the meaning of each field in the **tecwrksd** structure and indicates how the application should use each field. For more information about Host Integration Server 3270 configuration, see [Configuration Information](../core/configuration-information1.md).  
   
- *cwsestyp*  
- The LU type (display or printer) of the LU used by this session and (if it is a display LU or a pool of display LUs) the screen model. The possible values are:  
+*cwshost*  
+The name (up to eight characters) of the LU or LU pool that this session is configured to use. The application specifies this name on the [Open(SSCP) Request](./open-sscp-request2.md).  
+  
+*cwsestyp*  
+The LU type (display or printer) of the LU used by this session and (if it is a display LU or a pool of display LUs) the screen model. The possible values are:  
   
 - CERTMOD2 (0)        Model 2 display (24 by 80)  
   
@@ -62,7 +64,7 @@ typedef struct tecwrksd {
   
 - CERTPRNT (4)         Host printer  
   
-  The application should use this value to distinguish between display and printer sessions and to set the appropriate screen model for display sessions.  
+The application should use this value to distinguish between display and printer sessions and to set the appropriate screen model for display sessions.  
   
-  *cwsmodov*  
-  **TRUE** if the user has permission to override the screen model for display sessions—that is, to change the session to use a different screen model from the one configured. If this value is **FALSE**, the user should not be permitted to change the screen model. This field is not used for printer sessions and should not be checked.
+*cwsmodov*  
+**TRUE** if the user has permission to override the screen model for display sessions—that is, to change the session to use a different screen model from the one configured. If this value is **FALSE**, the user should not be permitted to change the screen model. This field is not used for printer sessions and should not be checked.

--- a/his/core/tecwrkus1.md
+++ b/his/core/tecwrkus1.md
@@ -15,6 +15,7 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # tecwrkus
+
 Tecwrkus is a 3270 user record, which includes a number of Tecwrksd LU/session information records.  
   
 ## Syntax  
@@ -41,104 +42,106 @@ typedef struct tecwrkus {
 } TECWRKUS;  
 ```  
   
-## Members  
- *cwlen*  
- Length of record.  
+## Members
   
- *cwtype*  
- Type of record.  
+*cwlen*  
+Length of record.  
   
- *cwname[21]*  
- User name.  
+*cwtype*  
+Type of record.  
   
- *cwremark[26]*  
- Comment field.  
+*cwname[21]*  
+User name.  
   
- *cwstylef[9]*  
- Initial style file name.  
+*cwremark[26]*  
+Comment field.  
   
- *cwvewrtm*  
- Whether user can view Response Time Monitor (RTM) information.  
+*cwstylef[9]*  
+Initial style file name.  
   
- *cwalert*  
- Whether user has ALERT permission.  
+*cwvewrtm*  
+Whether user can view Response Time Monitor (RTM) information.  
   
- *cwchghan*  
- Whether user can change LU/pool name accessed.  
+*cwalert*  
+Whether user has ALERT permission.  
   
- *cwmaxses*  
- Maximum number of active sessions (1–10).  
+*cwchghan*  
+Whether user can change LU/pool name accessed.  
   
- *cwnumrec*  
- Number of sessions for user.  
+*cwmaxses*  
+Maximum number of active sessions (1–10).  
   
- *cwsesdat[10]*  
- Session information records.  
+*cwnumrec*  
+Number of sessions for user.  
   
- *cwmodisf*  
- Permission to modify initial style.  
+*cwsesdat[10]*  
+Session information records.  
   
- *cwstatus*  
- Status byte: user or group.  
+*cwmodisf*  
+Permission to modify initial style.  
   
- *cwpad*  
- One byte of padding.  
+*cwstatus*  
+Status byte: user or group.  
   
- *cwnumrmp*  
- Number of LUs/pools in remap list.  
+*cwpad*  
+One byte of padding.  
   
- *cwremap[1]*  
- LU/pool remap list.  
+*cwnumrmp*  
+Number of LUs/pools in remap list.  
   
-## Remarks  
+*cwremap[1]*  
+LU/pool remap list.  
   
-## Members  
- *cwlen*  
- The length of the 3270 user record (this is variable because it contains a variable number of LU/session records in the remap list). The application should use this value to locate the start of the next 3270 user record when searching for the correct record.  
+## Remarks
+
+The following list of members explains the meaning of each field in the **tecwrkus** structure and indicates how the application should use each field. For more information about Host Integration Server 3270 configuration, see [Configuration Information](../core/configuration-information1.md).
+
+*cwlen*  
+The length of the 3270 user record (this is variable because it contains a variable number of LU/session records in the remap list). The application should use this value to locate the start of the next 3270 user record when searching for the correct record.  
   
- *cwtype*  
- Identifies this as a 3270 user record.  
+*cwtype*  
+Identifies this as a 3270 user record.  
   
- *cwname*  
- The Local Area Network (LAN) Manager user name, or other identifying name, of the 3270 user (up to 20 characters). The application uses this to search for the correct 3270 user record.  
+*cwname*  
+The Local Area Network (LAN) Manager user name, or other identifying name, of the 3270 user (up to 20 characters). The application uses this to search for the correct 3270 user record.  
   
- *cwremark*  
- An optional comment field (up to 25 characters), used in the configuration program to give more information about the user (for example, the user's full name).  
+*cwremark*  
+An optional comment field (up to 25 characters), used in the configuration program to give more information about the user (for example, the user's full name).  
   
- *cwstylef*  
- The name (up to eight characters) of the default style file used by this user (a file containing the user's 3270 customization settings, used by the Host Integration Server 3270 emulation programs). This field can be used to identify the equivalent file for your 3270 emulator, if appropriate.  
+*cwstylef*  
+The name (up to eight characters) of the default style file used by this user (a file containing the user's 3270 customization settings, used by the Host Integration Server 3270 emulation programs). This field can be used to identify the equivalent file for your 3270 emulator, if appropriate.  
   
- If this field is blank, no style file is used and the 3270 emulator should revert to its default settings (unless overridden by a style file specified by the user).  
+If this field is blank, no style file is used and the 3270 emulator should revert to its default settings (unless overridden by a style file specified by the user).  
   
- *cwvewrtm*  
- **TRUE** if this user is permitted to view a display of RTM statistics for his or her 3270 sessions. If this field is **FALSE**, the application should not display RTM statistics and should not display a last transaction time indicator (LTTI) on the status line of display sessions. For more information about the use of Response Time Monitor (RTM), see [Diagnostics Record Format](../core/diagnostics-record-format1.md).  
+*cwvewrtm*  
+**TRUE** if this user is permitted to view a display of RTM statistics for his or her 3270 sessions. If this field is **FALSE**, the application should not display RTM statistics and should not display a last transaction time indicator (LTTI) on the status line of display sessions. For more information about the use of Response Time Monitor (RTM), see [Diagnostics Record Format](../core/diagnostics-record-format1.md).  
   
- *cwalert*  
- **TRUE** if the user is permitted to send NetView user alerts. If this field is **FALSE**, the user should not be permitted to send alerts. For more information about the use of alerts, see [Diagnostics Record Format](../core/diagnostics-record-format1.md).  
+*cwalert*  
+**TRUE** if the user is permitted to send NetView user alerts. If this field is **FALSE**, the user should not be permitted to send alerts. For more information about the use of alerts, see [Diagnostics Record Format](../core/diagnostics-record-format1.md).  
   
- *cwchghan*  
- **TRUE** if the user is permitted to remap a 3270 session to use a different LU (in which case it can be changed to use any LU in the remap list—see **cwremap**). If this field is **FALSE**, the application should not allow the user to remap sessions.  
+*cwchghan*  
+**TRUE** if the user is permitted to remap a 3270 session to use a different LU (in which case it can be changed to use any LU in the remap list—see **cwremap**). If this field is **FALSE**, the application should not allow the user to remap sessions.  
   
- *cwmaxses*  
- The maximum number of active sessions permitted to this user. If the number of sessions configured (see **cwnumrec**) is greater than this, the user must not be allowed to activate more sessions at a time than this field specifies.  
+*cwmaxses*  
+The maximum number of active sessions permitted to this user. If the number of sessions configured (see **cwnumrec**) is greater than this, the user must not be allowed to activate more sessions at a time than this field specifies.  
   
- *cwnumrec*  
- The total number of sessions configured for this user. The user record always contains 10 LU/session records (see **cwsesdat**), but only this number of the records will be used—the remainder will be filled with zeros.  
+*cwnumrec*  
+The total number of sessions configured for this user. The user record always contains 10 LU/session records (see **cwsesdat**), but only this number of the records will be used—the remainder will be filled with zeros.  
   
- *cwsesdat*  
- Ten LU/session records. Some of these records can be filled with zeros, indicating that they are unused (**cwnumrec** gives the number of sessions that are used). The application should list, and allow the user to use, only the sessions that have valid session records here.  
+*cwsesdat*  
+Ten LU/session records. Some of these records can be filled with zeros, indicating that they are unused (**cwnumrec** gives the number of sessions that are used). The application should list, and allow the user to use, only the sessions that have valid session records here.  
   
- *cwmodisf*  
- **TRUE** if the user is permitted to modify the initial 3270 customization. If this field is **FALSE**, the application should use the customization defined by **cwstylef** (if specified); the user should not be allowed to make changes to this style, or to override it by loading a different style file.  
+*cwmodisf*  
+**TRUE** if the user is permitted to modify the initial 3270 customization. If this field is **FALSE**, the application should use the customization defined by **cwstylef** (if specified); the user should not be allowed to make changes to this style, or to override it by loading a different style file.  
   
- *cwstatus*  
- Indicates whether the user name in this record is a LAN Manager user name or group name. The least significant bit of this byte is **CERTGRUP (1)** for a group, and **zero** for a user. Other bits are not used.  
+*cwstatus*  
+Indicates whether the user name in this record is a LAN Manager user name or group name. The least significant bit of this byte is **CERTGRUP (1)** for a group, and **zero** for a user. Other bits are not used.  
   
- *cwpad*  
- Pad byte—not used by the application.  
+*cwpad*  
+Pad byte—not used by the application.  
   
- *cwnumrmp*  
- The number of LU/session records in the remap list (see **cwremap**).  
+*cwnumrmp*  
+The number of LU/session records in the remap list (see **cwremap**).  
   
- *cwremap*  
- The list of LU/session records, which indicates the LUs to which the user can remap sessions (if any). If the user is not permitted to remap sessions (see **cwchghan**), this list is not used and should not be checked by the application.
+*cwremap*  
+The list of LU/session records, which indicates the LUs to which the user can remap sessions (if any). If the user is not permitted to remap sessions (see **cwchghan**), this list is not used and should not be checked by the application.

--- a/his/core/tp-started2.md
+++ b/his/core/tp-started2.md
@@ -15,11 +15,12 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # TP_STARTED
+
 The **TP_STARTED** verb is issued by the invoking transaction program (TP), and notifies APPC that the TP is starting.  
   
- For the Microsoft® Windows® version 3.*x* system, it is recommended that you use the [WinAsyncAPPC](../core/winasyncappc1.md) function rather than the blocking version of this call.  
+For the Microsoft® Windows® version 3.*x* system, it is recommended that you use the [WinAsyncAPPC](../core/winasyncappc1.md) function rather than the blocking version of this call.  
   
- The following structure describes the verb control block used by the **TP_STARTED** verb.  
+The following structure describes the verb control block used by the **TP_STARTED** verb.  
   
 ## Syntax  
   
@@ -37,31 +38,30 @@ struct tp_started {
     unsigned char   syncpoint_rqd;  
 };   
 ```  
+
+## Members
   
-## Remarks  
+*opcode*  
+Supplied parameter. Specifies the verb operation code, AP_TP_STARTED.  
   
-## Members  
- *opcode*  
- Supplied parameter. Specifies the verb operation code, AP_TP_STARTED.  
+*opext*  
+Supplied parameter. Specifies the verb operation extension. If the AP_EXTD_VCB bit is set, this indicates that the **tp_started** structure includes the **syncpoint_rqd** member used for Sync Point support. Otherwise, the verb control block ends immediately after the **tp_name** member.  
   
- *opext*  
- Supplied parameter. Specifies the verb operation extension. If the AP_EXTD_VCB bit is set, this indicates that the **tp_started** structure includes the **syncpoint_rqd** member used for Sync Point support. Otherwise, the verb control block ends immediately after the **tp_name** member.  
+*reserv2*  
+A reserved field.  
   
- *reserv2*  
- A reserved field.  
+*primary_rc*  
+Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *primary_rc*  
- Returned parameter. Specifies the primary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
+*secondary_rc*  
+Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
   
- *secondary_rc*  
- Returned parameter. Specifies the secondary return code set by APPC at the completion of the verb. The valid return codes vary depending on the APPC verb issued. See Return Codes for valid error codes for this verb.  
-  
- *lu_alias*  
+*lu_alias*  
  Supplied parameter. Specifies the alias by which the local LU is known to the local TP.  
   
- The name must match an LU alias established during configuration. APPC checks the LU alias against the current Host Integration Server configuration file. Due to the client/server architecture used by Host Integration Server, however, this parameter is not validated until an [ALLOCATE](../core/allocate2.md) or [MC_ALLOCATE](../core/mc-allocate2.md) is performed.  
+The name must match an LU alias established during configuration. APPC checks the LU alias against the current Host Integration Server configuration file. Due to the client/server architecture used by Host Integration Server, however, this parameter is not validated until an [ALLOCATE](../core/allocate2.md) or [MC_ALLOCATE](../core/mc-allocate2.md) is performed.  
   
- This parameter is an 8-byte ASCII character string. It can consist of the following ASCII characters:  
+This parameter is an 8-byte ASCII character string. It can consist of the following ASCII characters:  
   
 - Uppercase letters  
   
@@ -71,21 +71,21 @@ struct tp_started {
   
 - Special characters $, #, % and @  
   
-  The first character of this string cannot be a space.  
+The first character of this string cannot be a space.  
   
-  If the value of this parameter is fewer than eight bytes in length, pad it on the right with ASCII spaces (0x20).  
+If the value of this parameter is fewer than eight bytes in length, pad it on the right with ASCII spaces (0x20).  
   
-  To use an LU from the default LU pool, set this field to eight hexadecimal zeros. For more information, see [Default LUs](../core/default-lus2.md).  
+To use an LU from the default LU pool, set this field to eight hexadecimal zeros. For more information, see [Default LUs](../core/default-lus2.md).  
   
-  *tp_id*  
-  Returned parameter. Identifies the newly established TP.  
+*tp_id*  
+Returned parameter. Identifies the newly established TP.  
   
-  *tp_name*  
-  Supplied parameter. Specifies the name of the local TP.  
+*tp_name*  
+Supplied parameter. Specifies the name of the local TP.  
   
-  Under the Host Integration Server implementation of APPC, this parameter is ignored when issued by **TP_STARTED**. However, this parameter is required if the program runs under the IBM ES for OS/2 version 1.0 implementation of APPC.  
+Under the Host Integration Server implementation of APPC, this parameter is ignored when issued by **TP_STARTED**. However, this parameter is required if the program runs under the IBM ES for OS/2 version 1.0 implementation of APPC.  
   
-  This parameter is a 64-byte EBCDIC character string and is case-sensitive. The **tp_name** parameter can consist of the following EDCDIC characters:  
+This parameter is a 64-byte EBCDIC character string and is case-sensitive. The **tp_name** parameter can consist of the following EDCDIC characters:  
   
 - Uppercase and lowercase letters  
   
@@ -93,23 +93,23 @@ struct tp_started {
   
 - Special characters $, #, @, and period (.)  
   
-  If the TP name is fewer than 64 bytes in length, use EBCDIC spaces (0x40) to pad it on the right.  
+If the TP name is fewer than 64 bytes in length, use EBCDIC spaces (0x40) to pad it on the right.  
   
-  The SNA convention for a service TP name is up to four characters. The first character is a hexadecimal byte between 0x00 and 0x3F.  
+The SNA convention for a service TP name is up to four characters. The first character is a hexadecimal byte between 0x00 and 0x3F.  
   
-  *syncpoint_rqd*  
-  This optional parameter is only applicable if the AP_EXTD_VCB bit is set in the **opext** parameter and Sync Point services are required.  
+*syncpoint_rqd*  
+This optional parameter is only applicable if the AP_EXTD_VCB bit is set in the **opext** parameter and Sync Point services are required.  
   
 - AP_YES if Sync Point is required.  
-  
 - AP_NO if Sync Point is not required.  
   
-## Return Codes  
- AP_OK  
- Primary return code; the verb executed successfully.  
+## Return Codes
   
- AP_COMM_SUBSYSTEM_ABENDED  
- Primary return code; indicates one of the following conditions:  
+AP_OK  
+Primary return code; the verb executed successfully.  
+  
+AP_COMM_SUBSYSTEM_ABENDED  
+Primary return code; indicates one of the following conditions:  
   
 - The node used by this conversation encountered an ABEND.  
   
@@ -117,33 +117,34 @@ struct tp_started {
   
 - The SnaBase at the TP's computer encountered an ABEND.  
   
-  The system administrator should examine the error log to determine the reason for the ABEND.  
+The system administrator should examine the error log to determine the reason for the ABEND.  
   
-  AP_COMM_SUBSYSTEM_NOT_LOADED  
-  Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
+AP_COMM_SUBSYSTEM_NOT_LOADED  
+Primary return code; a required component could not be loaded or terminated while processing the verb. Thus, communication could not take place. Contact the system administrator for corrective action.  
   
-  AP_INVALID_VERB_SEGMENT  
-  Primary return code; the VCB extended beyond the end of the data segment.  
+AP_INVALID_VERB_SEGMENT  
+Primary return code; the VCB extended beyond the end of the data segment.  
   
-  AP_STACK_TOO_SMALL  
-  Primary return code; the stack size of the application is too small to execute the verb. Increase the stack size of your application.  
+AP_STACK_TOO_SMALL  
+Primary return code; the stack size of the application is too small to execute the verb. Increase the stack size of your application.  
   
-  AP_TP_BUSY  
-  Primary return code; the local TP has issued a call to APPC while APPC was processing another call for the same TP.  
+AP_TP_BUSY  
+Primary return code; the local TP has issued a call to APPC while APPC was processing another call for the same TP.  
   
-  AP_THREAD_BLOCKING  
-  Primary return code; the calling thread is already in a blocking call.  
+AP_THREAD_BLOCKING  
+Primary return code; the calling thread is already in a blocking call.  
   
-  AP_UNEXPECTED_DOS_ERROR  
-  Primary return code; the operating system has returned an error to APPC while processing an APPC call from the local TP. The operating system return code is returned through the **secondary_rc**. It appears in Intel byte-swapped order. If the problem persists, consult the system administrator.  
+AP_UNEXPECTED_DOS_ERROR  
+Primary return code; the operating system has returned an error to APPC while processing an APPC call from the local TP. The operating system return code is returned through the **secondary_rc**. It appears in Intel byte-swapped order. If the problem persists, consult the system administrator.  
   
-## Remarks  
- In response to **TP_STARTED**, APPC generates a TP identifier for the invoking TP. This identifier is a required parameter for subsequent APPC verbs issued by the invoking TP.  
+## Remarks
   
- This must be the first APPC verb issued by the invoking TP. Consequently, no prior APPC state exists.  
+In response to **TP_STARTED**, APPC generates a TP identifier for the invoking TP. This identifier is a required parameter for subsequent APPC verbs issued by the invoking TP.  
   
- If the verb executes successfully (**primary_rc** is AP_OK), the state changes to RESET.  
+This must be the first APPC verb issued by the invoking TP. Consequently, no prior APPC state exists.  
+  
+If the verb executes successfully (**primary_rc** is AP_OK), the state changes to RESET.  
   
 ## In This Section  
   
--   [Default LUs](../core/default-lus2.md)
+- [Default LUs](../core/default-lus2.md)

--- a/his/core/trm-format-for-the-tcp-trm-link-programming-model2.md
+++ b/his/core/trm-format-for-the-tcp-trm-link-programming-model2.md
@@ -15,28 +15,29 @@ ms.author: "hisdocs"
 manager: "anneta"
 ---
 # TRM Format for the TCP TRM Link Programming Model
+
 This topic describes the format and content of the transaction request message (TRM) used by the TCP TRM Link programming model.  
   
-## TRM Request Message  
- The following table shows the contents of the request message.  
+## TRM Request Message
+  
+The following table shows the contents of the request message.  
   
 |TranID|Comma|Client in data|  
 |------------|-----------|--------------------|  
 |4|1|35|  
   
- TranID  
- Transaction ID of the Concurrent Server to be started by the Listener.  
+TranID  
+Transaction ID of the Concurrent Server to be started by the Listener.  
   
- Comma  
- A comma (,) separates the transaction ID from the Client in data.  
+Comma  
+A comma (,) separates the transaction ID from the Client in data.  
   
- Client in data  
- 35 bytes of data used by the CICS TCP/IP security exit and passed to the Concurrent Server in the transaction initiation message (TIM).  
+Client in data  
+35 bytes of data used by the CICS TCP/IP security exit and passed to the Concurrent Server in the transaction initiation message (TIM).  
   
-## Client in data for Microsoft Security Exit format  
- The following code block describes the format of the client in data for the Microsoft security exit.  
+## Client in data for Microsoft Security Exit format
   
-## Syntax  
+The following code block describes the format of the client in data for the Microsoft security exit.  
   
 ```  
 struct CLIENT_IN_DATA {  
@@ -48,10 +49,9 @@ struct CLIENT_IN_DATA {
 } UNALIGNED;  
 ```  
   
-## Client in data for IBM Security Exit format  
- The following code block describes the format of the client in data for the IBM security exit.  
+## Client in data for IBM Security Exit format
   
-## Syntax  
+The following code block describes the format of the client in data for the IBM security exit.  
   
 ```  
 struct CLIENT_IN_DATA2 {  
@@ -64,40 +64,42 @@ struct CLIENT_IN_DATA2 {
 } UNALIGNED;  
 ```  
   
-## TRM Reply Message  
- The following table shows the contents of the reply message.  
+## TRM Reply Message
+  
+The following table shows the contents of the reply message.  
   
 |TRM reply msg length|Formatted field length|Formatted field code|*Data*|  
 |--------------------------|----------------------------|--------------------------|------------|  
 |4|4|1|*0-n*|  
   
 > [!NOTE]
->  The formatted field length, formatted field code, and data can be repeated multiple times in a single message.  
+> The formatted field length, formatted field code, and data can be repeated multiple times in a single message.  
   
- TRM reply msg length  
- The total length of the TRM reply message. This length is the sum of all the lengths of the formatted fields that follow in the message and does not include the length of the TRM reply msg length field itself.  
+TRM reply msg length  
+The total length of the TRM reply message. This length is the sum of all the lengths of the formatted fields that follow in the message and does not include the length of the TRM reply msg length field itself.  
   
- Formatted field length  
- The length of the formatted field.  
+Formatted field length  
+The length of the formatted field.  
   
- The formatted field length is the sum of the combination of the Formatted field code length and the Data length.  
+The formatted field length is the sum of the combination of the Formatted field code length and the Data length.  
   
- Formatted field code  
- A 1-byte code that describes the information passed from the Concurrent Server back to the client.  
+Formatted field code  
+A 1-byte code that describes the information passed from the Concurrent Server back to the client.  
   
- You cannot change the Formatted field code.  
+You cannot change the Formatted field code.  
   
- The field codes are specific to the communication handling between the WIP and HIP TCP Transports and the MSCMTICS, MSHIPLNK and TCP Concurrent Server programs.  
+The field codes are specific to the communication handling between the WIP and HIP TCP Transports and the MSCMTICS, MSHIPLNK and TCP Concurrent Server programs.  
   
- *Data*  
- 0 or more bytes of information that is associated with a specific formatted field.  
+*Data*  
+0 or more bytes of information that is associated with a specific formatted field.  
   
- You may change the information stored in Data. If you change Data, be sure that you also change the TRM Reply and the Formatted Field Length to the new values.  
+You may change the information stored in Data. If you change Data, be sure that you also change the TRM Reply and the Formatted Field Length to the new values.  
   
- The length of Data is equal to the formatted field length minus the size of the formatted field code.  
+The length of Data is equal to the formatted field length minus the size of the formatted field code.  
   
-## Normal codes  
- The following table shows the meaning of the normal codes.  
+## Normal codes
+  
+The following table shows the meaning of the normal codes.  
   
 |Code|Type|Meaning|  
 |----------|----------|-------------|  
@@ -105,8 +107,9 @@ struct CLIENT_IN_DATA2 {
 |0x02|Info|User Data|  
 |0x07|Info|Execution OK|  
   
-## Error codes  
- The following table shows the meaning of the error codes.  
+## Error codes
+  
+The following table shows the meaning of the error codes.  
   
 |Code|Type|Meaning|  
 |----------|----------|-------------|  
@@ -118,7 +121,8 @@ struct CLIENT_IN_DATA2 {
 |0x09|Error|Execution Failed|  
 |0x0A|Error|Invalid TRM|  
   
- For more information about the format of the TRM, see the TRM definition file at \<drive>:\Program Files\Microsoft Host Integration Server\System\TIM\MicrosoftTRMDefs.tim. Use Visual Studio to view the file.  
+For more information about the format of the TRM, see the TRM definition file at \<drive>:\Program Files\Microsoft Host Integration Server\System\TIM\MicrosoftTRMDefs.tim. Use Visual Studio to view the file.  
   
-## See Also  
- [TRM Format for the TCP TRM User Data Programming Model](../core/trm-format-for-the-tcp-trm-user-data-programming-model2.md)
+## See Also
+
+- [TRM Format for the TCP TRM User Data Programming Model](../core/trm-format-for-the-tcp-trm-user-data-programming-model2.md)


### PR DESCRIPTION
Ripple 3 validation cleanup for duplicate H2s.

Replaced duplicate H2 headings for Syntax, Members, Remarks with introductory sentences and converted one article to a table of codes instead of using headings. 