### PR TITLE
Update how-to-restore-your-databases.md

### DIFF
--- a/biztalk/core/how-to-restore-your-databases.md
+++ b/biztalk/core/how-to-restore-your-databases.md
@@ -66,7 +66,7 @@ Sign in to SQL Server using an account that is a member of the sysadmin SQL Serv
     > [!NOTE]
     > When using a SQL Server 2016 or later environment, you may need to use MSOLEDBSQL in UpdateDatabase.vbs. In UpdateDatabase.vbs, go to `conn.Provider = "SQLOLEDB"`. Change `SQLOLEDB` to `MSOLEDBSQL`. Otherwise, the script may fail with error: `SQL Server: Invalid connection string attribute`.
     > 
-    > [Download MSOLEDBSQL 18.x](https://docs.microsoft.com/en-gb/sql/connect/oledb/release-notes-for-oledb-driver-for-sql-server?view=sql-server-ver15#previous-releases).
+    > [Download MSOLEDBSQL 18.x](/sql/connect/oledb/release-notes-for-oledb-driver-for-sql-server?view=sql-server-ver15#previous-releases).
     > 
     > This script updates all tables that store information about the location of other databases.
   

--- a/biztalk/core/how-to-restore-your-databases.md
+++ b/biztalk/core/how-to-restore-your-databases.md
@@ -64,9 +64,9 @@ Sign in to SQL Server using an account that is a member of the sysadmin SQL Serv
     `cscript UpdateDatabase.vbs SampleUpdateInfo.xml`
 
     > [!NOTE]
-    > When using a SQL Server 2016 environment, you may need to use MSOLEDBSQL in UpdateDatabase.vbs. In UpdateDatabase.vbs, go to `conn.Provider = "SQLOLEDB"`. Change `SQLOLEDB` to `MSOLEDBSQL`. Otherwise, the script may fail with error: `SQL Server: Invalid connection string attribute`.
+    > When using a SQL Server 2016 or later environment, you may need to use MSOLEDBSQL in UpdateDatabase.vbs. In UpdateDatabase.vbs, go to `conn.Provider = "SQLOLEDB"`. Change `SQLOLEDB` to `MSOLEDBSQL`. Otherwise, the script may fail with error: `SQL Server: Invalid connection string attribute`.
     > 
-    > [Download MSOLEDBSQL](https://www.microsoft.com/download/details.aspx?id=56730).
+    > [Download MSOLEDBSQL 18.x](https://docs.microsoft.com/en-gb/sql/connect/oledb/release-notes-for-oledb-driver-for-sql-server?view=sql-server-ver15#previous-releases).
     > 
     > This script updates all tables that store information about the location of other databases.
   


### PR DESCRIPTION
Linking to latest MSOLEDBSQL 18.x version official download page instead of obsolete download page. The latest 19 version has a different provider name unfortunately so this will not work.