### PR TITLE
LinkFix: biztalk-docs (2022-05)

### DIFF
--- a/biztalk/core/tools-and-utilities-to-use-for-troubleshooting.md
+++ b/biztalk/core/tools-and-utilities-to-use-for-troubleshooting.md
@@ -46,7 +46,7 @@ Fiddler is 3rd party/partner tool available at [Telerik Fiddler](https://www.tel
 For more information, go to [Test-Dtc](/powershell/module/msdtc/test-dtc).
 
 ## DTCPing
- Use the DTCPing tool to verify distributed transaction support across firewalls or against networks. The DTCPing tool must be installed on both the client and server computer and is a good alternative to the DTCTester utility when SQL Server is not installed on either computer. For more information about using DTCPing to verify distributed transaction support see [How to troubleshoot MS DTC firewall issues](/biztalk/core/troubleshooting-problems-with-msdtc).
+ Use the DTCPing tool to verify distributed transaction support across firewalls or against networks. The DTCPing tool must be installed on both the client and server computer and is a good alternative to the DTCTester utility when SQL Server is not installed on either computer. For more information about using DTCPing to verify distributed transaction support see [How to troubleshoot MS DTC firewall issues](./troubleshooting-problems-with-msdtc.md).
 
 ## Performance Console
  Use the Performance Console to capture performance monitoring data in your BizTalk Server environment. See [Performance Counters](../core/performance-counters.md) for a comprehensive list of the performance counters included with BizTalk Server.

--- a/biztalk/install-and-config-guides/troubleshoot-known-issues-biztalk-install-setup.md
+++ b/biztalk/install-and-config-guides/troubleshoot-known-issues-biztalk-install-setup.md
@@ -121,7 +121,7 @@ Function: FieldInfoCreate
  If BizTalk Server and SQL Server are installed on different computers, then the configuration operations are performed under the context of a Microsoft Distributed Transaction Coordinator (MSDTC) transaction and MSDTC functionality must be available over the network between these computers. If MSDTC functionality is not available over the network between the computers running BizTalk Server and SQL Server, then this error can occur.
 
 **Resolution**
-Use [Troubleshooting Problems with MSDTC](/biztalk/core/troubleshooting-problems-with-msdtc) to ensure MSDTC functionality over the network between the computers running BizTalk Server and SQL Server.
+Use [Troubleshooting Problems with MSDTC](../core/troubleshooting-problems-with-msdtc.md) to ensure MSDTC functionality over the network between the computers running BizTalk Server and SQL Server.
 
 ### Antivirus software interferes with configuration and causes configuration failures
 


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 