### PR TITLE
LinkFix: biztalk-docs (2022-09)

### DIFF
--- a/biztalk/adapters-and-accelerators/adapter-oracle-database/samples-for-the-oracle-database-adapter.md
+++ b/biztalk/adapters-and-accelerators/adapter-oracle-database/samples-for-the-oracle-database-adapter.md
@@ -25,7 +25,7 @@ Samples for [!INCLUDE[adapteroracle](../../includes/adapteroracle-md.md)] are ca
 - WCF channel model samples  
 
   
-The samples are available at [BizTalk Adapter Pack 2010: Oracle Database adapter samples](/biztalk/dev-center/biztalk-server-code-samples). The SQL scripts for creating the tables and packages used in the samples are included. 
+The samples are available at [BizTalk Adapter Pack 2010: Oracle Database adapter samples](../../dev-center/biztalk-server-code-samples.md). The SQL scripts for creating the tables and packages used in the samples are included. 
 
 > [!NOTE]
 > [!INCLUDE[files-need-updated](../../includes/files-need-updated.md)]

--- a/biztalk/adapters-and-accelerators/adapter-oracle-ebs/samples-for-the-oracle-ebs-adapter.md
+++ b/biztalk/adapters-and-accelerators/adapter-oracle-ebs/samples-for-the-oracle-ebs-adapter.md
@@ -26,7 +26,7 @@ Samples for [!INCLUDE[adapteroracleebusinesslong](../../includes/adapteroracleeb
   
 - Microsoft Office SharePoint Server samples  
   
-  The samples are available at [BizTalk Adapter Pack 2010: Oracle E-Business Suite adapter samples](/biztalk/dev-center/biztalk-server-code-samples). The SQL scripts for creating the interface tables, concurrent programs, tables, and packages used in the samples are included. 
+  The samples are available at [BizTalk Adapter Pack 2010: Oracle E-Business Suite adapter samples](../../dev-center/biztalk-server-code-samples.md). The SQL scripts for creating the interface tables, concurrent programs, tables, and packages used in the samples are included. 
   
 > [!NOTE]
 > [!INCLUDE[files-need-updated](../../includes/files-need-updated.md)]

--- a/biztalk/adapters-and-accelerators/adapter-siebel/samples-for-the-siebel-adapter.md
+++ b/biztalk/adapters-and-accelerators/adapter-siebel/samples-for-the-siebel-adapter.md
@@ -25,7 +25,7 @@ Samples for [!INCLUDE[adaptersiebel](../../includes/adaptersiebel-md.md)] are ca
 - [!INCLUDE[adoprovidersiebelshort](../../includes/adoprovidersiebelshort-md.md)] samples  
 
 
-The samples are available at [BizTalk Adapter Pack 2010: Siebel adapter samples](/biztalk/dev-center/biztalk-server-code-samples). 
+The samples are available at [BizTalk Adapter Pack 2010: Siebel adapter samples](../../dev-center/biztalk-server-code-samples.md). 
 
 > [!NOTE]
 > [!INCLUDE[files-need-updated](../../includes/files-need-updated.md)]

--- a/biztalk/adapters-and-accelerators/adapter-sql/samples-for-the-sql-adapter.md
+++ b/biztalk/adapters-and-accelerators/adapter-sql/samples-for-the-sql-adapter.md
@@ -25,7 +25,7 @@ Samples for [!INCLUDE[adaptersql](../../includes/adaptersql-md.md)] are categori
   
 - WCF channel model samples  
   
-The samples are available at [BizTalk Adapter Pack 2010: SQL adapter samples](/biztalk/dev-center/biztalk-server-code-samples). The SQL scripts for creating the objects used in the samples, such as database, tables, and procedures are included. 
+The samples are available at [BizTalk Adapter Pack 2010: SQL adapter samples](../../dev-center/biztalk-server-code-samples.md). The SQL scripts for creating the objects used in the samples, such as database, tables, and procedures are included. 
 
 > [!NOTE]
 > [!INCLUDE[files-need-updated](../../includes/files-need-updated.md)]

--- a/biztalk/core/step-1-deploy-the-projects.md
+++ b/biztalk/core/step-1-deploy-the-projects.md
@@ -35,7 +35,7 @@ manager: "anneta"
 - Run Visual Studio with Administrative privileges
 
 > [!TIP]
-> You can download the required tutorial files at [Tutorial 1: Enterprise Application Integration](/biztalk/core/tutorial-1-enterprise-application-integration).
+> You can download the required tutorial files at [Tutorial 1: Enterprise Application Integration](./tutorial-1-enterprise-application-integration.md).
 
 ## Open the solution with administrative rights  
   

--- a/biztalk/install-and-config-guides/install-biztalk-server-in-a-multi-computer-environment.md
+++ b/biztalk/install-and-config-guides/install-biztalk-server-in-a-multi-computer-environment.md
@@ -110,7 +110,7 @@ See [How to maintain and troubleshoot BizTalk Server databases](https://support.
 BizTalk Server provides several tools for information workers, among them BAM. A basic understanding of the component architecture helps you plan the BizTalk Server installation to utilize the server resources available to you.
 Business Activity Monitoring (BAM) is a collection of tools used to manage aggregations, alerts, and profiles to monitor relevant business metrics, known as key performance indicators or KPIs.
 
-BAM is a module that gives you end-to-end visibility into your business processes to provides information about the status and results of various operational processes and transactions. You can use the BAM output to address problem areas and resolve issues within your business. For more information about BAM life cycle, see [Business Activity Monitoring (BAM)](/biztalk/core/business-activity-monitoring-bam).
+BAM is a module that gives you end-to-end visibility into your business processes to provides information about the status and results of various operational processes and transactions. You can use the BAM output to address problem areas and resolve issues within your business. For more information about BAM life cycle, see [Business Activity Monitoring (BAM)](../core/business-activity-monitoring-bam.md).
 
 BAM consists of the following layers:
 


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 