### PR TITLE
Update ports-for-the-tracking-server.md

### DIFF
--- a/biztalk/core/ports-for-the-tracking-server.md
+++ b/biztalk/core/ports-for-the-tracking-server.md
@@ -26,8 +26,8 @@ For complete information about securing your BizTalk Server deployment, see [Sam
 |Service or Application context|Destination Server|Destination Service|Port|Protocol|Reason|  
 |------------------------------------|------------------------|-------------------------|----------|--------------|------------|  
 |Logged on user|BizTalk Management database|SQL Server|1433|TCP|To create and configure the BizTalk Management database|  
-|Logged on user|BizTalk Management database|DTC|135|TCP|Transacted connection to SQL Server to update and retrieve information from the database|  
-|Logged on user|BizTalk Management database|DTC|50000-50200|TCP|Secondary RPC ports **Note:**  You may need to open more secondary RPC ports depending on your server load.|  
+|Logged on user|BizTalk Management database|DTC|135|TCP|Transacted connection to SQL Server to update and retrieve information from the database. RPC endpoint manager.|  
+|Logged on user|BizTalk Management database|DTC|49152-65535|TCP|Secondary RPC ports **Note:**  You can change to larger dynamic port range or better use fixed port for MSDTC and EntSSO services.|  
 |Logged on user|SSO database|SQL Server|1433|TCP|For the SSO Service to connect to the SSO database|  
 |Logged on user|BAM Primary Import database|SQL Server|1433|TCP|To validate the BAM Primary Import database. The Tracking host connects to this database during run time.|  
 |Logged on user|BAM Star Schema database|SQL Server|1433||To update and retrieve information from the database. **Note:**  The Tracking host connects to this database only when you run the BizTalk Configuration Manager to create a new BizTalk group from this server.|  
@@ -36,12 +36,12 @@ For complete information about securing your BizTalk Server deployment, see [Sam
 |Logged on user|BAM Analysis database|OLAP|2725|TCP|For data retrieval for analysis (PivotTable reports) **Note:**  The Tracking host connects to this database only when you run the BizTalk Configuration Manager to create a new BizTalk group from this server.|  
 |Logged on user|Tracking database|SQL Server|1433|TCP|To update and retrieve information from the database|  
 |Logged on user|MessageBox database|SQL|1433|TCP|To update and retrieve information from the database|  
-|Logged on user|MessageBox database|DTC|135|TCO|Transacted connection to SQL Server|  
-|Logged on user|MessageBox database|DTC|50000-50200||Secondary RPC ports|  
+|Logged on user|MessageBox database|DTC|135|TCO|Transacted connection to SQL Server. RPC endpoint manager.|  
+|Logged on user|MessageBox database|DTC|49152-65535||Secondary RPC ports|  
 |Logged on user|BAM Archive database|SQL Server|1433|TCP|To update and retrieve information from the database **Note:**  The Tracking host connects to this database only when you run the BizTalk Configuration Manager to create a new BizTalk group from this server.|  
 |SSO service account|SSO database|SQL Server|1433|TCP|To update and retrieve information from the database|  
-|SSO service account|Master secret server|Master Secret service|135|TCP|Transacted connection to SQL Server for the SSO service to connect to the master secret server|  
-|SSO service account|Master secret server|Secondary RPC|50000-50200|TCP|Secondary RPC ports for SSO service to connect to the master secret server|  
+|SSO service account|Master secret server|Master Secret service|135|TCP|Transacted connection to SQL Server for the SSO service to connect to the master secret server. RPC endpoint manager.|  
+|SSO service account|Master secret server|Secondary RPC|49152-65535|TCP|Secondary RPC ports for SSO service to connect to the master secret server|  
   
 ## See Also  
  [Server Naming Conventions](../core/server-naming-conventions.md)   


### PR DESCRIPTION
Changing old Windows 2003 era recommendation of only 200 ports for MSDTC and EntSSO to instead use default range of 49152-65535 to avoid port exhaustion