### PR TITLE
Update ports-for-the-bam-portal-server.md

### DIFF
--- a/biztalk/core/ports-for-the-bam-portal-server.md
+++ b/biztalk/core/ports-for-the-bam-portal-server.md
@@ -24,22 +24,22 @@ For complete information about securing your BizTalk Server deployment, see [Sam
 |------------------------------------|------------------------|-------------------------|----------|--------------|------------|  
 |Logged on user|BizTalk Management database|SQL Server|1433|TCP|To create and configure the database|  
 |Logged on user|BizTalk Management database|DTC|135|TCP|Transacted connection to SQL Server for creating, configure, and update the database|  
-|Logged on user|BizTalk Management database|DTC|50000-50200|TCP|Secondary RPC ports to create and connect to this database **Note:**  You may need to open more secondary RPC ports depending on your server load.|  
+|Logged on user|BizTalk Management database|DTC|49152-65535|TCP|Secondary RPC ports to create and connect to this database **Note:**  You can change to larger dynamic port range or better use fixed port for MSDTC and EntSSO services.|  
 |Application pool|Inbound clients|HTTP(S)|80 or 443|TCP|For inbound traffic for the Web Site|  
 |Logged on user|MessageBox database|SQL server|1433|TCP|To create and configure the database|  
 |Logged on user|MessageBox database|DTC|135|TCP|Transacted connection to SQL Server for creating, configure, and update the database|  
-|Logged on user|MessageBox database|DTC|50000-50200|TCP|Secondary RPC ports **Note:**  You may need to open more secondary RPC ports depending on your server load.|  
+|Logged on user|MessageBox database|DTC|49152-65535|TCP|Secondary RPC ports **Note:**  You can change to larger dynamic port range or better use fixed port for MSDTC and EntSSO services.|  
 |SSO service account|SSO database|SQL server|1433|TCP|To connect to SSO database|  
 |Logged on user|Tracking database|SQL Server|1433|TCP|To create and configure the database|  
 |Logged on user|Business Rule Engine database|SQL Server|1433|TCP|To create and configure the database|  
 |Logged on user|Business Rule Engine database|DTC|135|TCP|Transacted connection to SQL Server to create, configure, and update the database|  
-|Logged on user|Business Rule Engine database|DTC|50000-50200|TCP|Secondary RPC ports **Note:**  You may need to open more secondary RPC ports depending on your server load.|  
+|Logged on user|Business Rule Engine database|DTC|49152-65535|TCP|Secondary RPC ports **Note:**  You can change to larger dynamic port range or better use fixed port for MSDTC and EntSSO services.|  
 |Logged on user|BAM Analysis database|OLAP|2393|TCP|To create and configure the database|  
 |Logged on user|BAM Analysis database|OLAP Server file system|445|TCP|Create OLAP data file (.mdb) on the remote computer|  
 |Logged on user|BAM Analysis database|OLAP|2725|TCP|To update and retrieve information from the database|  
 |SSO service account|SSO database|SQL Server|1433|TCP|For the SSO service to update and retrieve information from the database|  
 |SSO service account|Master secret server|Master secret server|135|TCP|Transacted connection to SQL Server for the SSO service to connect to the master secret server|  
-|SSO Service|Master secret server|Secondary RPC|50000-50200|TCP|Secondary RPC ports for the SSO service to connect to the master secret server. **Note:**  You may need to open more secondary RPC ports depending on your server load.|  
+|SSO Service|Master secret server|Secondary RPC|49152-65535|TCP|Secondary RPC ports for the SSO service to connect to the master secret server. **Note:**  You can change to larger dynamic port range or better use fixed port for MSDTC and EntSSO services.|  
 |BizTalk Host instance|MessageBox database|SQL Server|1433|TCP|To update and retrieve information from the database during run time operations|  
 |BizTalk Host instance|BizTalk Management database|SQL Server|1433|TCP|To update and retrieve information from the database during run time operations|  
 |BizTalk Host instance|SSO database|SQL Server|1433|TCP|To update and retrieve information from the database during run time operations|  


### PR DESCRIPTION
Changing old Windows 2003 era recommendation of only 200 ports for MSDTC and EntSSO to instead use default range of 49152-65535 to avoid port exhaustion