### PR TITLE
Update hardware-and-software-requirements-for-biztalk-server-2020.md

### DIFF
--- a/biztalk/install-and-config-guides/hardware-and-software-requirements-for-biztalk-server-2020.md
+++ b/biztalk/install-and-config-guides/hardware-and-software-requirements-for-biztalk-server-2020.md
@@ -39,8 +39,8 @@ The following table lists the minimum hardware requirements for your BizTalk Ser
 When applying a cumulative update, some of the required software versions may change. To see the software versions that are updated, read the KB article for the cumulative update. For a list of cumulative updates, go to [Service Pack and cumulative update list for BizTalk Server](https://support.microsoft.com/topic/service-pack-and-cumulative-update-list-for-biztalk-server-108e5e94-4558-8b57-d5fb-45984506d56f).
 
 - **Microsoft Windows**: Required. Supported versions include:
-  - Windows Server 2019
-  - Windows Server 2016
+  - Windows Server 2019 (with Desktop Experience)
+  - Windows Server 2016 (with Desktop Experience)
   - Windows 10
 
 - **Internet Information Services (IIS)**: Provides a scalable web application infrastructure, and is required for EDI, BAM, Management REST API, and the SharePoint adapter.


### PR DESCRIPTION
Added "with Desktop Experience" to Windows Server requirements since BizTalk does not support the "Core" installation option.  Reference https://learn.microsoft.com/en-us/windows-server/administration/server-core/what-is-server-core#server-core-vs-server-with-desktop-experience