### PR TITLE
Update step-2-configure-a-two-way-wcf-webhttp-send-port.md

### DIFF
--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -61,7 +61,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          >
          >
          > Use the following version instead: 
-           >`Url=”/Customer?{ID}&amp;amp;group={Location}”`
+         > `Url="/Customer?{ID}&amp;amp;group={Location}"`
 
     3.  On the **Bindings** tab, for the **Maximum Received Message Size** field, select a sufficiently large value. That’s because typically the response message containing the flight status is considerably large and might exceed the default message size specified.
 

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -60,7 +60,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > `Url="/Customer?{ID}&amp;group={Location}"`
          >
          >
-           >Use:
+         > Use the following version instead: 
            >`Url=”/Customer?{ID}&amp;amp;group={Location}”`
 
     3.  On the **Bindings** tab, for the **Maximum Received Message Size** field, select a sufficiently large value. That’s because typically the response message containing the flight status is considerably large and might exceed the default message size specified.

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -47,7 +47,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
 
          > Within the URL field, you must "escape" any special XML characters to make sure that the port 
          > processes and preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
-           >
+         >
            >For:
            >`Url=”/Customer?{ID}&group={Location}”`
            >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -54,7 +54,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > Use the following text instead: 
          > `Url="/Customer?{ID}&amp;group={Location}"`
          >
-         > If the REST service also requires the special character be escaped within the URL used at runtime, double-escaping may be required.
+         > If the REST service also requires that you escape the special character within the URL used at runtime, you might have to use double-escaping.
            >
            >For:
            >`Url=”/Customer?{ID}&amp;group={Location}”`

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -40,7 +40,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
 
         ```
 
-         Here, **GET** is the HTTP verb and **On_Time_Performance** is appended to the base URI to construct a unique resource URL to retrieve flight delays.
+         Here, **GET** is the HTTP verb, and **On_Time_Performance** is appended to the base URI to construct a unique resource URL to retrieve flight delays.
 
          > [!IMPORTANT]
          >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -52,7 +52,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          >
          >
          > Use the following text instead: 
-           >`Url=”/Customer?{ID}&amp;group={Location}”`
+         > `Url="/Customer?{ID}&amp;group={Location}"`
            >
          > If the REST service also requires the special character be escaped within the URL used at runtime, double-escaping may be required.
            >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -44,7 +44,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
 
          > [!IMPORTANT]
          >
-         > Within the URL field, you must "escape" any special XML characters to make sure that the port 
+         > Within the URL field, you must "escape" any special XML characters to make sure that the port processes and 
          > processes and preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
          >
          > For the following text:

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -50,7 +50,6 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > For the following text:
          > `Url="/Customer?{ID}&group={Location}"`
          >
-         >
          > Use the following version instead: 
          > `Url="/Customer?{ID}&amp;group={Location}"`
          >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -45,7 +45,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > [!IMPORTANT]
          >
          > Within the URL field, you must "escape" any special XML characters to make sure that the port processes and 
-         > processes and preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
+         > preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
          >
          > For the following text:
          > `Url="/Customer?{ID}&group={Location}"`

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -48,7 +48,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > Within the URL field, you must "escape" any special XML characters to make sure that the port 
          > processes and preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
          >
-           >For:
+         > For the following text:
            >`Url=”/Customer?{ID}&group={Location}”`
            >
            >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -55,7 +55,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > `Url="/Customer?{ID}&amp;group={Location}"`
          >
          > If the REST service also requires that you escape the special character within the URL used at runtime, you might have to use double-escaping.
-           >
+         >
            >For:
            >`Url=”/Customer?{ID}&amp;group={Location}”`
            >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -50,7 +50,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > For the following text:
          > `Url="/Customer?{ID}&group={Location}"`
          >
-           >
+         >
            >Use:
            >`Url=”/Customer?{ID}&amp;group={Location}”`
            >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -49,7 +49,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > processes and preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
          >
          > For the following text:
-           >`Url=”/Customer?{ID}&group={Location}”`
+         > `Url="/Customer?{ID}&group={Location}"`
            >
            >
            >Use:

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -57,7 +57,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > If the REST service also requires that you escape the special character within the URL used at runtime, you might have to use double-escaping.
          >
          > For the following text: 
-           >`Url=”/Customer?{ID}&amp;group={Location}”`
+         > `Url="/Customer?{ID}&amp;group={Location}"`
            >
            >
            >Use:

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -59,7 +59,6 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > For the following text: 
          > `Url="/Customer?{ID}&amp;group={Location}"`
          >
-         >
          > Use the following version instead: 
          > `Url="/Customer?{ID}&amp;amp;group={Location}"`
 

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -44,7 +44,6 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
 
          > [!IMPORTANT]
          >
-
          > Within the URL field, you must "escape" any special XML characters to make sure that the port 
          > processes and preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
          >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -49,7 +49,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          >
          > For the following text:
          > `Url="/Customer?{ID}&group={Location}"`
-           >
+         >
            >
            >Use:
            >`Url=”/Customer?{ID}&amp;group={Location}”`

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -45,12 +45,21 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > [!TIP]
          > Within the URL field, any special XML characters must be "escaped". This ensures that the special XML characters are processed, and preserved by the port. For example, the `&` special character must be escaped as `&amp;`.
            >
-           >From:
-           >`Url=”/Customer?{ID}& group=Location”`
+           >For:
+           >`Url=”/Customer?{ID}&group={Location}”`
            >
            >
-           >To:
-           >`Url=”/Customer?{ID}&amp;group=Location”`
+           >Use:
+           >`Url=”/Customer?{ID}&amp;group={Location}”`
+           >
+         > If the REST service also requires the special character be escaped within the URL used at runtime, double-escaping may be required.
+           >
+           >For:
+           >`Url=”/Customer?{ID}&amp;group={Location}”`
+           >
+           >
+           >Use:
+           >`Url=”/Customer?{ID}&amp;amp;group={Location}”`
 
     3.  On the **Bindings** tab, for the **Maximum Received Message Size** field, select a sufficiently large value. That’s because typically the response message containing the flight status is considerably large and might exceed the default message size specified.
 

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -51,7 +51,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > `Url="/Customer?{ID}&group={Location}"`
          >
          >
-           >Use:
+         > Use the following text instead: 
            >`Url=”/Customer?{ID}&amp;group={Location}”`
            >
          > If the REST service also requires the special character be escaped within the URL used at runtime, double-escaping may be required.

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -42,7 +42,9 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
 
          Here, **GET** is the HTTP verb and **On_Time_Performance** is appended to the base URI to construct a unique resource URL to retrieve flight delays.
 
-         > [!TIP]
+         > [!IMPORTANT]
+         >
+
          > Within the URL field, any special XML characters must be "escaped". This ensures that the special XML characters are processed, and preserved by the port. For example, the `&` special character must be escaped as `&amp;`.
            >
            >For:

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -56,7 +56,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          >
          > If the REST service also requires that you escape the special character within the URL used at runtime, you might have to use double-escaping.
          >
-           >For:
+         > For the following text: 
            >`Url=”/Customer?{ID}&amp;group={Location}”`
            >
            >

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -59,7 +59,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > For the following text: 
          > `Url="/Customer?{ID}&amp;group={Location}"`
          >
-           >
+         >
            >Use:
            >`Url=”/Customer?{ID}&amp;amp;group={Location}”`
 

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -45,7 +45,8 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > [!IMPORTANT]
          >
 
-         > Within the URL field, any special XML characters must be "escaped". This ensures that the special XML characters are processed, and preserved by the port. For example, the `&` special character must be escaped as `&amp;`.
+         > Within the URL field, you must "escape" any special XML characters to make sure that the port 
+         > processes and preserves the special characters. For example, you must escape the `&` special character as `&amp;`.
            >
            >For:
            >`Url=”/Customer?{ID}&group={Location}”`

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -51,7 +51,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          > `Url="/Customer?{ID}&group={Location}"`
          >
          >
-         > Use the following text instead: 
+         > Use the following version instead: 
          > `Url="/Customer?{ID}&amp;group={Location}"`
          >
          > If the REST service also requires that you escape the special character within the URL used at runtime, you might have to use double-escaping.

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -53,7 +53,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          >
          > Use the following text instead: 
          > `Url="/Customer?{ID}&amp;group={Location}"`
-           >
+         >
          > If the REST service also requires the special character be escaped within the URL used at runtime, double-escaping may be required.
            >
            >For:

--- a/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
+++ b/biztalk/core/step-2-configure-a-two-way-wcf-webhttp-send-port.md
@@ -58,7 +58,7 @@ In this step you configure a two-way **WCF-WebHttp** send port to invoke the RES
          >
          > For the following text: 
          > `Url="/Customer?{ID}&amp;group={Location}"`
-           >
+         >
            >
            >Use:
            >`Url=”/Customer?{ID}&amp;amp;group={Location}”`


### PR DESCRIPTION
Corrected extra space and missing curly brackets in the Tip for URL Mapping.  Also added comments and example about double-escaping when the REST service requires xml-escaped characters in the URL.